### PR TITLE
mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,9 @@
       xmlns:fb="http://ogp.me/ns/fb#">
   <head>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css"/>
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="viewport" content="width=device-width,  initial-scale=1, maximum-scale=1.0, user-scalable = no"/>
   </head>
   <body>
     <div id="root"/>

--- a/src/components/ActionMenu.css
+++ b/src/components/ActionMenu.css
@@ -28,7 +28,7 @@
   top: 100%;
   background-color: #F2F2F2;
   display: none;
-  z-index: 10;
+  z-index: 12;
 }
 
 .active .action-menu--list {

--- a/src/components/cell.css
+++ b/src/components/cell.css
@@ -14,6 +14,7 @@
 }
 
 .cell--wrapper {
+  position: relative;
   border: 2px solid transparent;
   box-sizing: border-box;
   width: 100%;
@@ -63,15 +64,14 @@
 }
 
 .cell--number {
-  display: inline-block;
+  position: absolute;
+  top: 2px;
+  left: 2px;
   font-size: 150%;
-  margin-top: 5%;
-  margin-left: 5%;
   margin-right: auto;
   flex: 3;
   line-height: 98%;
   height: 5px;
-  padding: 1%;
   background-color: transparent;
   z-index: 11;
 }
@@ -95,12 +95,24 @@
 }
 
 .cell--value {
-  flex: 7;
-  padding: 0 5% 5% 5%;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
   text-align: center;
   vertical-align: middle;
   font-size: 350%;
   z-index: 11;
+}
+
+.tiny .cell--number {
+  top: 0px;
+  left: 0px;
+}
+
+.small .cell--number {
+  top: 1px;
+  left: 1px;
 }
 
 .cell--cursors {

--- a/src/components/cell.js
+++ b/src/components/cell.js
@@ -36,7 +36,7 @@ export default class Cell extends Component {
           <div key={i} className='cell--cursor' style={{
             borderColor: color,
             zIndex: Math.min(2 + this.props.cursors.length - i, 9),
-            borderWidth: Math.min(1 + 2 * (i + 1), 16)
+            borderWidth: Math.min(1 + 2 * (i + 1), 12)
           }}>
         </div>
         ))}
@@ -115,7 +115,23 @@ export default class Cell extends Component {
             ? { backgroundColor: this.props.myColor }
             : null
         }
-        onClick={this.props.onClick}>
+        onClick={this.props.onClick}
+        onTouchMove={e => {
+          if (e.touches.length >= 1) {
+            window.lastZoomed = new Date().getTime();
+          } else {
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        }}
+        onTouchEnd={e => {
+          e.preventDefault();
+          const now = new Date().getTime();
+          const disablePeriod = 200;
+          if (!window.lastZoomed || window.lastZoomed + disablePeriod < now) {
+            this.props.onClick(e);
+          }
+        }}>
         <div className='cell--wrapper'>
 
           <div className={'cell--number' + (this.props.number
@@ -125,7 +141,6 @@ export default class Cell extends Component {
           { this.props.number }
         </div>
         { this.renderFlipButton() }
-        { this.renderCursors() }
         { this.renderCircle() }
         <div className='cell--value'
           style={{
@@ -136,6 +151,7 @@ export default class Cell extends Component {
           { val }
         </div>
       </div>
+      { this.renderCursors() }
     </div>
     );
   }

--- a/src/components/grid.js
+++ b/src/components/grid.js
@@ -70,15 +70,28 @@ export default class Grid extends Component {
     );
   }
 
+  getSizeClass(size) {
+    if (size < 20) {
+      return 'tiny';
+    } else if (size < 25) {
+      return 'small';
+    } else if (size < 40) {
+      return 'medium';
+    } else {
+      return 'big';
+    }
+  }
+
   render() {
     const size = this.props.size;
+    const sizeClass = this.getSizeClass(size);
     return (
       <table
         style={{
           width: this.props.grid[0].length * this.props.size,
           height: this.props.grid.length * this.props.size
         }}
-        className='grid'>
+        className={'grid ' + sizeClass}>
         <tbody>
           {
             this.props.grid.map((row, r) => (

--- a/src/components/gridControls.js
+++ b/src/components/gridControls.js
@@ -60,10 +60,8 @@ export default class GridControls extends Component {
     this.setSelected(firstEmptyCell || clueRoot);
   }
 
-  handleKeyDown(ev) {
-    if (ev.target.tagName === 'INPUT') {
-      return;
-    }
+  // factored out handleAction for mobileGridControls
+  handleAction(action, shiftKey) {
     const moveSelectedBy = (dr, dc) => () => {
       const { selected } = this.props;
       let { r, c } = selected;
@@ -92,33 +90,56 @@ export default class GridControls extends Component {
         cbk();
       }
     }
+
     const flipDirection = () => {
       if (this.props.direction === 'across') {
-        if(this.canSetDirection('down')) {
+        if (this.canSetDirection('down')) {
             this.setDirection('down');
         }
       } else {
-        if(this.canSetDirection('across')) {
+        if (this.canSetDirection('across')) {
             this.setDirection('across');
         }
       }
     }
 
-    const { onPressEnter } = this.props;
-    const movement = {
-      'ArrowLeft': setDirection('across', moveSelectedBy(0, -1)),
-      'ArrowUp': setDirection('down', moveSelectedBy(-1, 0)),
-      'ArrowDown': setDirection('down', moveSelectedBy(1, 0)),
-      'ArrowRight': setDirection('across', moveSelectedBy(0, 1)),
-      'Backspace': this.backspace.bind(this),
-      'Tab': this.selectNextClue.bind(this),
-      ' ': flipDirection,
+    const actions = {
+      'left': setDirection('across', moveSelectedBy(0, -1)),
+      'up': setDirection('down', moveSelectedBy(-1, 0)),
+      'down': setDirection('down', moveSelectedBy(1, 0)),
+      'right': setDirection('across', moveSelectedBy(0, 1)),
+      'backspace': this.backspace.bind(this),
+      'tab': this.selectNextClue.bind(this),
+      'space': flipDirection,
     };
 
-    if (ev.key in movement) {
+    if (!(action in actions)) {
+      console.error('illegal action', action);
+      return; // weird!
+    }
+    actions[action](shiftKey);
+  }
+
+  handleKeyDown(ev) {
+    if (ev.target.tagName === 'INPUT') {
+      return;
+    }
+
+    const actionKeys = {
+      'ArrowLeft': 'left',
+      'ArrowUp': 'up',
+      'ArrowDown': 'down',
+      'ArrowRight': 'right',
+      'Backspace': 'backspace',
+      'Tab': 'tab',
+      ' ': 'space',
+    };
+
+    const { onPressEnter } = this.props;
+    if (ev.key in actionKeys) {
       ev.preventDefault();
       ev.stopPropagation();
-      movement[ev.key](ev.shiftKey);
+      this.handleAction(actionKeys[ev.key], ev.shiftKey);
     } else if (ev.key === 'Enter') {
       ev.preventDefault();
       ev.stopPropagation();

--- a/src/components/mobileGridControls.css
+++ b/src/components/mobileGridControls.css
@@ -1,0 +1,35 @@
+.movement-arrow {
+  display: inline-block;
+  padding: 5px;
+  /* border-radius 5px; */
+  border: 1px solid black;
+  text-transform: uppercase;
+  outline: none;
+}
+
+.mobile-grid-controls {
+  outline: none;
+  position: relative;
+}
+
+.mobile-grid-controls--textarea--wrapper {
+  position: absolute;
+  top: 115px;
+}
+
+.mobile-grid-controls--textarea {
+  font-size: 30px;
+  transform: scale(0);
+}
+
+.mobile-grid-controls--focus-button {
+  width: 100%;
+  background-color: #FFF;
+  color: black;
+  text-transform: uppercase;
+  font-family: Avenir;
+  padding: 10px;
+  font-size: 20px;
+  border-radius: 3px;
+  border: 1px solid black;
+}

--- a/src/components/mobileGridControls.js
+++ b/src/components/mobileGridControls.js
@@ -1,0 +1,76 @@
+import './mobileGridControls.css';
+
+import React from 'react';
+import GridControls from './gridControls';
+
+function MovementArrow({ dir, onClick }) {
+  return (
+    <div
+      className={'movement-arrow ' + dir}
+      tabIndex={-1}
+      autoComplete="off"
+      autoCorrect="off"
+      autoCapitalize="off"
+      spellCheck="false"
+      onTouchStart={function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        onClick();
+      }}
+    >
+      { dir }
+    </div>
+  );
+}
+
+export default class MobileGridControls extends GridControls {
+  render() {
+    return (
+      <div
+        ref='gridControls'
+        className='mobile-grid-controls'
+        onKeyDown={this.handleKeyDown.bind(this)}
+      >
+          <div className='grid--content'>
+            {this.props.children}
+          </div>
+        <div className='mobile-grid-controls--buttons'>
+          {
+            // ['left', 'right', 'up', 'down'].map((dir, i) => (
+            [].map((dir, i) => (
+              <MovementArrow
+                key={i}
+                dir={dir}
+                onClick={() => {
+                  this.handleAction(dir)
+                }}
+              />
+            ))
+          }
+        </div>
+        <div className='mobile-grid-controls--textarea--wrapper'>
+          <textarea
+            type="text"
+            ref="textarea"
+            className='mobile-grid-controls--textarea'
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck="false"
+          />
+        </div>
+        <button
+          className='mobile-grid-controls--focus-button'
+          onTouchStart={(e) => {
+          this.refs.textarea.focus();
+        }}
+        onTouchEnd={e=> {
+          e.preventDefault();
+        }}
+      >
+        Type
+      </button>
+    </div>
+    );
+  }
+}

--- a/src/components/player.css
+++ b/src/components/player.css
@@ -44,3 +44,35 @@
 
 .player--main--clues {
 }
+
+
+.player--mobile {
+  display: flex;
+  flex-direction: column;
+  justify-content: stretch;
+}
+
+.player--mobile--grid {
+}
+
+.player--mobile--clue-bar {
+  margin-top: 10px;
+  background-color: #DCEFFF;
+  padding: 10px 20px 10px 20px;
+  display: flex;
+  font-size: 15px;
+  height: 40px;
+  align-items: center;
+}
+
+.player--mobile--clue-bar--number {
+  font-weight: bold;
+  display: inline-block;
+}
+
+.player--mobile--clue-bar--text {
+  margin-left: 20px;
+  display: inline-block;
+  overflow-y: scroll;
+  max-height: 100%;
+}

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -3,6 +3,7 @@ import './player.css';
 import Grid from './grid';
 import Clues from './clues';
 import GridControls from './gridControls';
+import MobileGridControls from './mobileGridControls';
 import React, { Component } from 'react';
 import { lazy } from '../jsUtils';
 
@@ -14,7 +15,7 @@ import * as gameUtils from '../gameUtils';
  *
  * Props: { grid, clues, updateGrid }
  *
- * State: { selected, direction }
+ * State: { selected, direction, mobileMode }
  *
  * Children: [ GridControls, Grid, Clues ]
  * - GridControls.props:
@@ -42,6 +43,7 @@ export default class Player extends Component {
         c: 0
       },
       direction: 'across',
+      mobile: false,
     };
 
     // for deferring scroll-to-clue actions
@@ -202,32 +204,95 @@ export default class Player extends Component {
       this.prvNum[dir] = num;
       lazy('scrollToClue' + dir, () => {
         const parent = el.offsetParent;
-        parent.scrollTop = el.offsetTop - (parent.offsetHeight * .4);
+        if (parent) {
+          parent.scrollTop = el.offsetTop - (parent.offsetHeight * .4);
+        }
       });
     }
   }
 
-
   /* Render */
-
   render() {
     const {
+      mobile,
       onPressEnter,
+      size,
+      grid,
+      clues,
+      circles,
+      cursors,
+      updateGrid,
+      frozen,
+      myColor,
     } = this.props;
+
+    const {
+      selected,
+      direction,
+    } = this.state;
+
+    if (mobile) {
+      return (
+        <div className='player--mobile--wrapper mobile'>
+
+          <MobileGridControls
+            ref='mobileGridControls'
+            onPressEnter={onPressEnter}
+            selected={selected}
+            direction={direction}
+            onSetDirection={this._setDirection}
+            canSetDirection={this._canSetDirection}
+            onSetSelected={this._setSelected}
+            updateGrid={updateGrid}
+            grid={grid}
+            clues={clues}
+          >
+            <div className='player--mobile'>
+              <div
+                className={'player--mobile--grid' + (frozen ? ' frozen' : '')}
+              >
+
+              <Grid
+                ref='grid'
+                size={size}
+                grid={grid}
+                circles={circles}
+                selected={selected}
+                references={this.getReferences()}
+                direction={direction}
+                cursors={cursors}
+                onSetSelected={this._setSelected}
+                myColor={myColor}
+                onChangeDirection={this._changeDirection}/>
+            </div>
+
+            <div className='player--mobile--clue-bar'>
+              <div className='player--mobile--clue-bar--number'>
+                { this.getClueBarAbbreviation() }
+              </div>
+              <div className='player--mobile--clue-bar--text'>
+                { this.getClueBarText() }
+              </div>
+            </div>
+          </div>
+        </MobileGridControls>
+      </div>
+      );
+    }
 
     return (
       <div className='player--main--wrapper'>
         <GridControls
           ref='gridControls'
           onPressEnter={onPressEnter}
-          selected={this.state.selected}
-          direction={this.state.direction}
+          selected={selected}
+          direction={direction}
           onSetDirection={this._setDirection}
           canSetDirection={this._canSetDirection}
           onSetSelected={this._setSelected}
-          updateGrid={this.props.updateGrid}
-          grid={this.props.grid}
-          clues={this.props.clues}
+          updateGrid={updateGrid}
+          grid={grid}
+          clues={clues}
         >
           <div className='player--main'>
             <div className='player--main--left'>
@@ -241,19 +306,19 @@ export default class Player extends Component {
               </div>
 
               <div
-                className={'player--main--left--grid' + (this.props.frozen ? ' frozen' : '') + ' blurable'}
+                className={'player--main--left--grid' + (frozen ? ' frozen' : '') + ' blurable'}
               >
                 <Grid
                   ref='grid'
-                  size={this.props.size}
-                  grid={this.props.grid}
-                  circles={this.props.circles}
-                  selected={this.state.selected}
+                  size={size}
+                  grid={grid}
+                  circles={circles}
+                  selected={selected}
                   references={this.getReferences()}
-                  direction={this.state.direction}
-                  cursors={this.props.cursors}
+                  direction={direction}
+                  cursors={cursors}
                   onSetSelected={this._setSelected}
-                  myColor={this.props.myColor}
+                  myColor={myColor}
                   onChangeDirection={this._changeDirection}/>
               </div>
             </div>

--- a/src/components/toolbar.css
+++ b/src/components/toolbar.css
@@ -1,5 +1,5 @@
 .toolbar {
-  padding: 10px 380px 8px 50px;
+  padding: 10px 10px 8px 50px;
   height: 20px;
   border-top: 1px solid #E2E2E2;
   border-left: 1px solid #E2E2E2;
@@ -15,5 +15,38 @@
 }
 
 .toolbar--timer {
+  text-align: center;
+}
+
+.toolbar--mobile--top {
+  padding: 10px 10px 8px 50px;
+  height: 20px;
+  border-top: 1px solid #E2E2E2;
+  border-left: 1px solid #E2E2E2;
+  border-right: 1px solid #E2E2E2;
+  border-bottom: 1px solid #E2E2E2;
+
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  align-items: center;
+  position: relative;
+  text-align: center;
+}
+
+
+.toolbar--mobile--bottom {
+  padding: 10px 10px 8px 50px;
+  height: 20px;
+  border-top: 1px solid #E2E2E2;
+  border-left: 1px solid #E2E2E2;
+  border-right: 1px solid #E2E2E2;
+  border-bottom: 1px solid #E2E2E2;
+
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  align-items: center;
+  position: relative;
   text-align: center;
 }

--- a/src/components/toolbar.js
+++ b/src/components/toolbar.js
@@ -63,36 +63,96 @@ export default class Toolbar extends Component {
   }
 
   render() {
+    const {
+      mobile,
+      startTime,
+      stopTime,
+      pausedTime,
+      onStartClock,
+      onPauseClock,
+      solved,
+    } = this.props;
+
+    if (mobile) {
+      return (
+        <div className='toolbar--mobile'>
+          <div className='toolbar--mobile--top'>
+            {
+              solved
+                ? null
+                : this.renderCheckMenu()
+            }
+            {
+              solved
+                ? null
+                : this.renderRevealMenu()
+            }
+            <div className='toolbar--menu reset'>
+              {
+                this.renderResetMenu()
+              }
+            </div>
+          </div>
+          <div className='toolbar--mobile--bottom'>
+            <div className='toolbar--mobile--timer'>
+              <Clock
+                startTime={startTime}
+                stopTime={stopTime}
+                pausedTime={pausedTime}
+              />
+            </div>
+            {
+              solved
+                ? null
+                : ( startTime
+                  ? ( <button className='toolbar--mobile--btn pause'
+                    onClick={onPauseClock} >
+                    Pause Clock
+                  </button>)
+                  : ( <button className='toolbar--mobile--btn start'
+                    onClick={onStartClock} >
+                    Start Clock
+                  </button>)
+                )
+            }
+
+          </div>
+        </div>
+      );
+
+
+    }
+
     return (
       <div className='toolbar'>
         <div className='toolbar--timer'>
           <Clock
-            startTime={this.props.startTime}
-            stopTime={this.props.stopTime}
-            pausedTime={this.props.pausedTime}
+            startTime={startTime}
+            stopTime={stopTime}
+            pausedTime={pausedTime}
           />
         </div>
         {
-          this.props.solved
+          solved
             ? null
-            : ( this.props.startTime
+            : ( startTime
               ? ( <button className='toolbar--btn pause'
-                onClick={this.props.onPauseClock} >
+                onClick={onPauseClock} >
                 Pause Clock
               </button>)
               : ( <button className='toolbar--btn start'
-                onClick={this.props.onStartClock} >
+                onClick={onStartClock} >
                 Start Clock
               </button>)
             )
         }
         {
-          this.props.solved
+          solved
             ? null
             : this.renderCheckMenu()
         }
         {
-          this.props.solved
+          solved
             ? null
             : this.renderRevealMenu()
         }
@@ -103,5 +163,6 @@ export default class Toolbar extends Component {
         </div>
       </div>
     );
+
   }
 };

--- a/src/containers/room.css
+++ b/src/containers/room.css
@@ -3,20 +3,27 @@
   height: 100%;
 }
 
-.room--info {
+.room--header {
   border: 1px solid #E2E2E2;
   padding: 20px 20px 20px 20px;
   color: #333;
 }
 
-.room--info--title {
+.room.mobile .room--header {
+  display: none;
+}
+
+.header {
+}
+
+.header--title {
   font-size: 30px;
   font-weight: 300;
   color: #333;
   text-decoration: none;
 }
 
-.room--info--subtitle {
+.header--subtitle {
   margin-top: 10px;
   font-size: 14px;
   font-weight: 300;
@@ -27,7 +34,20 @@
 
 .room--game-and-chat-wrapper {
   border: 1px solid #E2E2E2;
-  padding: 15px 15px 15px 15px;
+  padding: 15px;
   display: flex;
   flex-direction: row;
+}
+
+.room.mobile .room--game-and-chat-wrapper {
+  padding: 0px;
+}
+
+
+.toggle-mobile {
+  display: block;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  font-size: 10px;
 }


### PR DESCRIPTION
## Feature Changes
- Add Mobile: ON/OFF button at the top-left of page, toggling mobile/desktop view
  - Site should detect mobile correctly by default, but this link is there in case a user wants to see the other version for some reason (mobile wanting to chat or desktop wanting to see what mobile looks like)
- Mobile interface has tighter layout that hopefully fits on the screen without needing to scroll
  - Mobile Toolbar is split into 2 rows
  - Clues list is hidden, so is chat. In the future the chat will live in another view that can be accessed from the page somewher
- Grid responds to `touchend` events instead of click, which feels much faster and doesn't have focus issues
- Mobile keyboard is shown by tapping a "TYPE" button at the bottom of screen, and in theory should stay out until user dismisses it.
  - For some reason it can disappear on some gesture combinations (haven't reliably reproduced this yet)

## Code Changes
- Refactor GridControls to allow MobileGridControls to subclass it
- MobileGridControls provides a hidden Textarea that serves to request the mobile keyboard. 
  - There's no way to directly access the mobile keyboard api, it has to be done through the mobile browser by focusing an input or textarea or contenteditable.
  - The textarea causes the page to scroll when it's focused, and currently it's positioned so that the page scrolls to the top of the grid (hopefully)
- Refactor `cell.css` and `grid.js` to classify size of grid as tiny, small, medium, large (corresponding roughly to the cell sizes of to Sunday-Mobile, Sunday/Daily-Mobile, Daily, Mini) and set the margins for the clue numbers / clue values according to the class
- Room, Player, Toolbar all take a boolean `props.mobile` and render accordingly