### PR TITLE
Add a button to .puz uploader to create unlisted (url only) puzzles

### DIFF
--- a/src/components/Upload.js
+++ b/src/components/Upload.js
@@ -11,6 +11,7 @@ export default class Upload extends Component {
     this.state = {
       puzzle: null,
       recentlyCreatedPuzzleId: null,
+      unlistedCheckboxChecked: false,
     };
   }
 
@@ -18,11 +19,13 @@ export default class Upload extends Component {
     this.setState({
       puzzle: {...puzzle},
       recentlyCreatedPuzzleId: null,
+      unlistedCheckboxChecked: false,
     });
   };
 
-  create = (isPrivate = false) => {
-    const {puzzle} = this.state;
+  create = () => {
+    const {puzzle, unlistedCheckboxChecked} = this.state;
+    const isPrivate = unlistedCheckboxChecked;
     if (isPrivate) {
       puzzle.private = true;
     }
@@ -51,6 +54,12 @@ export default class Upload extends Component {
     }
   }
 
+  handleChangeUnlistedCheckbox = (e) => {
+    this.setState({
+      unlistedCheckboxChecked: e.target.checked,
+    });
+  };
+
   renderButton() {
     const {v2} = this.props;
     const {info} = this.state.puzzle || {};
@@ -58,11 +67,17 @@ export default class Upload extends Component {
     if (type) {
       return (
         <div>
-          <button className={'upload--button ' + (v2 ? 'v2' : '')} onClick={(e) => this.create(false)}>
-            {`Add puzzle to the public ${type} repository`}
-          </button>
-          <button className={'upload--button ' + (v2 ? 'v2' : '')} onClick={(e) => this.create(true)}>
-            {`Create puzzle but keep it unlisted (accessible by URL only)`}
+          <label>
+            <input
+              type="checkbox"
+              checked={this.state.unlistedCheckboxChecked}
+              onChange={this.handleChangeUnlistedCheckbox}
+            />{' '}
+            Unlisted
+          </label>
+          <button className={'upload--button ' + (v2 ? 'v2' : '')} onClick={this.create}>
+            {`Add puzzle to the ${type} repository`}
+            {this.state.unlistedCheckboxChecked ? ' (unlisted)' : ''}
           </button>
         </div>
       );

--- a/src/components/Upload.js
+++ b/src/components/Upload.js
@@ -8,18 +8,32 @@ import React, {Component} from 'react';
 export default class Upload extends Component {
   constructor() {
     super();
-    this.state = {puzzle: null};
+    this.state = {
+      puzzle: null,
+      recentlyCreatedPuzzleId: null,
+    };
   }
 
   success = (puzzle) => {
-    this.setState({puzzle: {...puzzle}});
+    this.setState({
+      puzzle: {...puzzle},
+      recentlyCreatedPuzzleId: null,
+    });
   };
 
-  create = () => {
+  create = (isPrivate = false) => {
     const {puzzle} = this.state;
-    actions.createPuzzle(puzzle, (puzzle) => {
+    if (isPrivate) {
+      puzzle.private = true;
+    }
+    actions.createPuzzle(puzzle, (pid) => {
       this.setState({puzzle: null});
       this.props.onCreate && this.props.onCreate();
+      if (isPrivate) {
+        this.setState({
+          recentlyCreatedPuzzleId: pid,
+        });
+      }
     });
   };
 
@@ -43,11 +57,34 @@ export default class Upload extends Component {
     const {type} = info || {};
     if (type) {
       return (
-        <button className={'upload--button ' + (v2 ? 'v2' : '')} onClick={this.create}>
-          {`Add to the ${type} repository`}
-        </button>
+        <div>
+          <button className={'upload--button ' + (v2 ? 'v2' : '')} onClick={(e) => this.create(false)}>
+            {`Add puzzle to the public ${type} repository`}
+          </button>
+          <button className={'upload--button ' + (v2 ? 'v2' : '')} onClick={(e) => this.create(true)}>
+            {`Create puzzle but keep it unlisted (accessible by URL only)`}
+          </button>
+        </div>
       );
     }
+  }
+
+  renderRecentlyCreatedPuzzleMessage() {
+    if (!this.state.recentlyCreatedPuzzleId) {
+      return;
+    }
+
+    const url = `${window.location.host}/beta/play/${this.state.recentlyCreatedPuzzleId}`;
+
+    return (
+      <p style={{marginTop: 10, marginBottom: 10}}>
+        Successfully created an unlisted puzzle. You may now visit the link{' '}
+        <a href={url} style={{wordBreak: 'break-all'}}>
+          {url}
+        </a>{' '}
+        to play the new puzzle.
+      </p>
+    );
   }
 
   render() {
@@ -59,6 +96,7 @@ export default class Upload extends Component {
             <FileUploader success={this.success} fail={this.fail} v2={v2} />
             {this.renderSuccessMessage()}
             {this.renderButton()}
+            {this.renderRecentlyCreatedPuzzleMessage()}
           </div>
         </div>
       </div>


### PR DESCRIPTION
<img width="178" alt="Screen Shot 2019-05-27 at 6 17 46 PM" src="https://user-images.githubusercontent.com/15852255/58444205-ea4a1f80-80ab-11e9-8fe1-cd0b8087b64d.png">

This change adds a second button to the .puz file Upload component shown after choosing a .puz file. The second button also creates a new puzzle but it sets `private: true` so the puzzle does not appear in the public list of puzzles. After the database transaction, it shows a message to the user with a link to the /beta/play/<pid> url to start a new game with the uploaded puzzle.