### PR TITLE
Display user presented under chat bar

### DIFF
--- a/src/components/Chat/css/index.css
+++ b/src/components/Chat/css/index.css
@@ -58,6 +58,17 @@
   cursor: initial;
 }
 
+.chat--users--present {
+  padding: 5px;
+  margin-bottom: 5px;
+}
+
+.chat--users--present span {
+  margin-left: 5px;
+  margin-right: 8px;
+  white-space: nowrap;
+}
+
 .chat--messages {
   flex: 1;
   overflow-x: auto;

--- a/src/components/Chat/css/index.css
+++ b/src/components/Chat/css/index.css
@@ -63,10 +63,13 @@
   margin-bottom: 5px;
 }
 
-.chat--users--present span {
+.chat--users--present > span {
   margin-left: 5px;
   margin-right: 8px;
-  white-space: nowrap;
+}
+
+.chat--users--present .dot {
+  padding-right: 5px;
 }
 
 .chat--messages {

--- a/src/components/Chat/index.js
+++ b/src/components/Chat/index.js
@@ -260,7 +260,6 @@ export default class Chat extends Component {
     const color = this.getMessageColor(id, isOpponent);
     const users = this.props.users;
 
-    this.props.updateSeenChatMessage && this.props.updateSeenChatMessage(message);
     return (
       <div className={'chat--message' + (big ? ' big' : '')}>
         {this.renderMessageSender(users[id].displayName, color)}

--- a/src/components/Chat/index.js
+++ b/src/components/Chat/index.js
@@ -161,7 +161,8 @@ export default class Chat extends Component {
     };
     return (
       <span key={id} style={style}>
-        {'\u25CF'} {displayName}
+        <span className="dot">{'\u25CF'}</span>
+        {displayName}{' '}
       </span>
     );
   }

--- a/src/components/Chat/index.js
+++ b/src/components/Chat/index.js
@@ -45,10 +45,12 @@ export default class Chat extends Component {
     localStorage.setItem(this.usernameKey, username);
   };
 
-  handleChangeUsername = (username) => {
+  handleUpdateDisplayName = (username) => {
     if (!this.usernameInput.current.focused) {
       username = username || nameGenerator();
     }
+    const {id} = this.props;
+    this.props.onUpdateDisplayName(id, username);
     this.setState({username});
   };
 
@@ -86,9 +88,9 @@ export default class Chat extends Component {
   }
 
   getMessageColor(senderId, isOpponent) {
-    const {colors} = this.props;
+    const {users} = this.props;
     if (isOpponent === undefined) {
-      return colors[senderId];
+      return users[senderId].color;
     }
     return isOpponent ? 'rgb(220, 107, 103)' : 'rgb(47, 137, 141)';
   }
@@ -143,7 +145,7 @@ export default class Chat extends Component {
           className="chat--username--input"
           mobile={this.props.mobile}
           value={this.state.username}
-          onChange={this.handleChangeUsername}
+          onChange={this.handleUpdateDisplayName}
           onBlur={this.handleBlur}
           onUnfocus={this.focus}
         />
@@ -152,23 +154,7 @@ export default class Chat extends Component {
   }
 
   renderUsersPresent() {
-    return this.props.hideChatBar ? null : (
-      <div className="chat--users-present">
-        {messages.map((message, i) => (
-          <div key={i}>{this.renderMessage(message)}</div>
-        ))}
-        {'You are '}
-        <EditableSpan
-          ref={this.usernameInput}
-          className="chat--username--input"
-          mobile={this.props.mobile}
-          value={this.state.username}
-          onChange={this.handleChangeUsername}
-          onBlur={this.handleBlur}
-          onUnfocus={this.focus}
-        />
-      </div>
-    );
+    return this.props.hideChatBar ? null : <div className="chat--users-present" />;
   }
 
   renderChatBar() {
@@ -283,6 +269,7 @@ export default class Chat extends Component {
 
   render() {
     const messages = this.mergeMessages(this.props.data, this.props.opponentData);
+    console.log(this.props.users);
 
     return (
       <Flex column grow={1}>

--- a/src/components/Chat/index.js
+++ b/src/components/Chat/index.js
@@ -151,6 +151,26 @@ export default class Chat extends Component {
     );
   }
 
+  renderUsersPresent() {
+    return this.props.hideChatBar ? null : (
+      <div className="chat--users-present">
+        {messages.map((message, i) => (
+          <div key={i}>{this.renderMessage(message)}</div>
+        ))}
+        {'You are '}
+        <EditableSpan
+          ref={this.usernameInput}
+          className="chat--username--input"
+          mobile={this.props.mobile}
+          value={this.state.username}
+          onChange={this.handleChangeUsername}
+          onBlur={this.handleBlur}
+          onUnfocus={this.focus}
+        />
+      </div>
+    );
+  }
+
   renderChatBar() {
     if (this.props.hideChatBar) {
       return null;
@@ -270,6 +290,7 @@ export default class Chat extends Component {
         <div className="chat">
           {this.renderChatHeader()}
           {this.renderUsernameInput()}
+          {this.renderUsersPresent()}
           <div
             ref={(el) => {
               if (el) {

--- a/src/components/Game/index.js
+++ b/src/components/Game/index.js
@@ -161,7 +161,7 @@ export default class Game extends Component {
       return <div>Loading...</div>;
     }
 
-    const {grid, circles, shades, cursors, pings, colors, clues, solved, solution, themeColor} = this.game;
+    const {grid, circles, shades, cursors, pings, users, clues, solved, solution, themeColor} = this.game;
     const opponentGrid = this.opponentGame && this.opponentGame.grid;
     const {screenWidth} = this.state;
     const themeStyles = {
@@ -204,7 +204,7 @@ export default class Game extends Component {
         id={id}
         cursors={cursors}
         pings={pings}
-        colors={colors}
+        users={users}
         frozen={solved}
         myColor={myColor}
         updateGrid={this.handleUpdateGrid}

--- a/src/components/Player/index.js
+++ b/src/components/Player/index.js
@@ -296,7 +296,6 @@ export default class Player extends Component {
         color: users[ping.id].color,
       }))
       .filter(({active}) => active);
-    console.log(pings);
     const {direction} = this.state;
     const selected = this.selected;
 

--- a/src/components/Player/index.js
+++ b/src/components/Player/index.js
@@ -273,7 +273,7 @@ export default class Player extends Component {
       updateGrid,
       frozen,
       myColor,
-      colors = {},
+      users = {},
       id,
       pickups,
       clueBarStyle = {},
@@ -286,14 +286,14 @@ export default class Player extends Component {
     const cursors = allCursors.filter((cursor) => cursor.id !== id).map((cursor) => ({
       ...cursor,
       active: cursor.timestamp > currentTime - CURSOR_TIMEOUT,
-      color: colors[cursor.id],
+      color: users[cursor.id].color,
     }));
     const pings = allPings
       .map((ping) => ({
         ...ping,
         active: ping.timestamp > currentTime - PING_TIMEOUT,
         age: (currentTime - ping.timestamp) / PING_TIMEOUT,
-        color: colors[ping.id],
+        color: users[ping.id].color,
       }))
       .filter(({active}) => active);
     console.log(pings);

--- a/src/lib/reducers/game.js
+++ b/src/lib/reducers/game.js
@@ -44,6 +44,7 @@ const reducers = {
         paused: true,
       },
       cursors = [],
+      usernames = {}, // mapping from id -> user display name
       colors = {},
       solved = false,
       themeColor = MAIN_BLUE_3,
@@ -61,6 +62,7 @@ const reducers = {
       clock,
       solved,
       cursors,
+      usernames,
       colors,
       themeColor,
     };
@@ -108,6 +110,20 @@ const reducers = {
     return {
       ...game,
       pings,
+    };
+  },
+
+  updateUsername: (game, params) => {
+    let {usernames = {}} = game;
+
+    const {id, username} = params;
+    usernames = {
+      ...usernames,
+      [id]: username,
+    };
+    return {
+      ...game,
+      usernames,
     };
   },
 

--- a/src/lib/reducers/game.js
+++ b/src/lib/reducers/game.js
@@ -44,8 +44,10 @@ const reducers = {
         paused: true,
       },
       cursors = [],
-      usernames = {}, // mapping from id -> user display name
-      colors = {},
+      // users is a mapping from id -> user info. fields include:
+      // color: string
+      // displayName: string
+      users = {},
       solved = false,
       themeColor = MAIN_BLUE_3,
       // themeColor = GREENISH,
@@ -62,8 +64,7 @@ const reducers = {
       clock,
       solved,
       cursors,
-      usernames,
-      colors,
+      users,
       themeColor,
     };
   },
@@ -113,31 +114,35 @@ const reducers = {
     };
   },
 
-  updateUsername: (game, params) => {
-    let {usernames = {}} = game;
-
-    const {id, username} = params;
-    usernames = {
-      ...usernames,
-      [id]: username,
+  updateDisplayName: (game, params) => {
+    let {users = {}} = game;
+    const {id, displayName} = params;
+    users = {
+      ...users,
+      [id]: {
+        ...users[id],
+        displayName,
+      },
     };
     return {
       ...game,
-      usernames,
+      users,
     };
   },
 
   updateColor: (game, params) => {
-    let {colors = {}} = game;
-
+    let {users = {}} = game;
     const {id, color} = params;
-    colors = {
-      ...colors,
-      [id]: color,
+    users = {
+      ...users,
+      [id]: {
+        ...users[id],
+        color,
+      },
     };
     return {
       ...game,
-      colors,
+      users,
     };
   },
 

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -194,8 +194,8 @@ export default class Game extends Component {
     this.gameModel.chat(username, id, message);
   };
 
-  handleChangeUsername = (username, id, message) => {
-    this.gameModel.chat(username, id, message);
+  handleUpdateDisplayName = (id, displayName) => {
+    this.gameModel.updateDisplayName(id, displayName);
   };
 
   updateSeenChatMessage = (message) => {
@@ -294,11 +294,11 @@ export default class Game extends Component {
         }}
         info={this.game.info}
         data={this.game.chat}
-        colors={this.game.colors}
+        users={this.game.users}
         id={id}
         myColor={color}
         onChat={this.handleChat}
-        onChangeUsername={this.handleChangeUsername}
+        onUpdateDisplayName={this.handleUpdateDisplayName}
         onUnfocus={this.handleUnfocusChat}
         onToggleChat={this.handleToggleChat}
         mobile={mobile}

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -194,6 +194,10 @@ export default class Game extends Component {
     this.gameModel.chat(username, id, message);
   };
 
+  handleChangeUsername = (username, id, message) => {
+    this.gameModel.chat(username, id, message);
+  };
+
   updateSeenChatMessage = (message) => {
     if (message.timestamp > this.state.lastReadChat) {
       this.setState({lastReadChat: message.timestamp});
@@ -294,6 +298,7 @@ export default class Game extends Component {
         id={id}
         myColor={color}
         onChat={this.handleChat}
+        onChangeUsername={this.handleChangeUsername}
         onUnfocus={this.handleUnfocusChat}
         onToggleChat={this.handleToggleChat}
         mobile={mobile}

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -135,6 +135,17 @@ export default class Game extends EventEmitter {
     });
   }
 
+  updateUsername(id, username) {
+    this.events.push({
+      timestamp: SERVER_TIME,
+      type: 'updateUsername',
+      params: {
+        id,
+        username,
+      },
+    });
+  }
+
   updateColor(id, color) {
     this.events.push({
       timestamp: SERVER_TIME,

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -135,13 +135,13 @@ export default class Game extends EventEmitter {
     });
   }
 
-  updateUsername(id, username) {
+  updateDisplayName(id, displayName) {
     this.events.push({
       timestamp: SERVER_TIME,
-      type: 'updateUsername',
+      type: 'updateDisplayName',
       params: {
         id,
-        username,
+        displayName,
       },
     });
   }


### PR DESCRIPTION
Changes:
- displays user presented under chat bar, with reasonable wrapping if name is too long
- moves user information (color, displayname) to a single object in the reducer
- messages now show current name corresponding to each sender (instead of the sender name at the time of message sent)