### PR TITLE
Add an info button with the rules for how to use the app

### DIFF
--- a/src/components/Toolbar/Popup.js
+++ b/src/components/Toolbar/Popup.js
@@ -1,0 +1,49 @@
+import './css/Popup.css';
+import React, {Component} from 'react';
+
+/*
+ * Summary of Popup component
+ *
+ * Props: { icon, label, onBlur }
+ *
+ * State: { active }
+ *
+ * Potential parents (so far):
+ * - Toolbar
+ * */
+
+export default class Popup extends Component {
+  constructor() {
+    super();
+    this.state = {
+      active: false,
+    };
+  }
+
+  onClick() {
+    this.setState({active: !this.state.active});
+  }
+
+  onBlur() {
+    this.setState({active: false});
+    this.props.onBlur();
+  }
+
+  render() {
+    return (
+      <div className={`${this.state.active ? 'active ' : ''}popup-menu`} onBlur={this.onBlur.bind(this)}>
+        <button
+          tabIndex={-1}
+          className={`popup-menu--button fa ${this.props.icon ? this.props.icon : ''}`}
+          onMouseDown={(e) => {
+            e.preventDefault();
+          }}
+          onClick={this.onClick.bind(this)}
+        >
+          {this.props.label ? this.props.label : ''}
+        </button>
+        <div className="popup-menu--content">{this.props.children}</div>
+      </div>
+    );
+  }
+}

--- a/src/components/Toolbar/css/Popup.css
+++ b/src/components/Toolbar/css/Popup.css
@@ -1,0 +1,52 @@
+.popup-menu {
+  font-size: 14px;
+}
+
+.popup-menu--button:hover {
+  background-color: white;
+  color: #000;
+}
+
+.popup-menu--content {
+  position: absolute;
+  top: 100%;
+  background-color: var(--main-gray-3);
+  padding: 20px;
+  display: none;
+  z-index: 12;
+  width: 33%;
+  color: #000;
+}
+
+.popup-menu--content ul {
+  padding-left: inherit;
+}
+
+.popup-menu--content li {
+  padding-bottom: 15px;
+}
+
+.popup-menu--content li:last-child {
+  padding-bottom: 0px;
+}
+
+.active .popup-menu--content {
+  display: block;
+}
+
+.popup-menu--content--popup:first-child {
+  border-top: 1px solid var(--main-gray-2);
+}
+
+.popup-menu--content--popup {
+  text-align: left;
+  padding: 15px;
+  border-left: 1px solid var(--main-gray-2);
+  border-bottom: 1px solid var(--main-gray-2);
+  border-right: 1px solid var(--main-gray-2);
+  cursor: pointer;
+}
+
+.toolbar--mobile--top .popup-menu--list--popup {
+  padding: 5px;
+}

--- a/src/components/Toolbar/css/Popup.css
+++ b/src/components/Toolbar/css/Popup.css
@@ -2,6 +2,21 @@
   font-size: 14px;
 }
 
+.popup-menu table {
+  border-collapse: collapse;
+}
+
+.popup-menu--content tr:nth-child(even) {
+  background-color: #ffffff;
+}
+
+.popup-menu table,
+th,
+td {
+  border: 1px solid black;
+  padding: 10px;
+}
+
 .popup-menu--button:hover {
   background-color: white;
   color: #000;
@@ -14,7 +29,7 @@
   padding: 20px;
   display: none;
   z-index: 12;
-  width: 33%;
+  width: 40%;
   color: #000;
 }
 
@@ -32,6 +47,7 @@
 
 .active .popup-menu--content {
   display: block;
+  cursor: auto;
 }
 
 .popup-menu--content--popup:first-child {
@@ -44,7 +60,6 @@
   border-left: 1px solid var(--main-gray-2);
   border-bottom: 1px solid var(--main-gray-2);
   border-right: 1px solid var(--main-gray-2);
-  cursor: pointer;
 }
 
 .toolbar--mobile--top .popup-menu--list--popup {

--- a/src/components/Toolbar/css/index.css
+++ b/src/components/Toolbar/css/index.css
@@ -77,6 +77,10 @@
   cursor: pointer;
 }
 
+.toolbar--info {
+  cursor: pointer;
+}
+
 .toolbar--pencil.on .fa-pencil {
   color: var(--main-blue) !important;
 }

--- a/src/components/Toolbar/css/index.css
+++ b/src/components/Toolbar/css/index.css
@@ -1,3 +1,8 @@
+code {
+  font-family: monospace;
+  background-color: rgb(223, 223, 223);
+}
+
 .toolbar {
   padding: 10px 10px 8px 50px;
   min-height: 20px;

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -131,15 +131,62 @@ export default class Toolbar extends Component {
     return (
       <div className={'toolbar--info'}>
         <Popup icon="fa-info-circle" onBlur={this.handleBlur}>
-          <strong>How to Enter Answers:</strong>
+          <h3>How to Enter Answers</h3>
           <ul>
             <li>
-              You can click a square once to enter an answer, and click that same square again to switch
-              between a down or across for that square
+              Click a cell once to enter an answer, and click that same cell again to switch between
+              horizontal and vertical orientations
             </li>
-            <li>You can also click the questions to go straight to answering them</li>
-            <li>You can hold down the shift key to enter multiple characters for rebus answers</li>
+            <li>Click the clues to move the cursor directly to the cell for that answer</li>
+            <li>
+              Hold down the <code>Shift</code> key to enter multiple characters for rebus answers
+            </li>
           </ul>
+          <h4>Keyboard Shortcuts</h4>
+          <table>
+            <tr>
+              <th>Shortcut</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>Letter / Number</td>
+              <td>Fill in current cell and advance cursor to next unfilled cell in the same word, if any</td>
+            </tr>
+            <tr>
+              <td>
+                <code>.</code> (period)
+              </td>
+              <td>Toggle pencil mode on/off</td>
+            </tr>
+            <tr>
+              <td>Arrow keys</td>
+              <td>
+                Either move cursor along current orientation or change orientation without moving cursor
+              </td>
+            </tr>
+            <tr>
+              <td>Space bar</td>
+              <td>Flip orientation between down/across</td>
+            </tr>
+            <tr>
+              <td>
+                <code>[</code> and <code>]</code>
+              </td>
+              <td>Move cursor perpendicular to current orientation without changing orientation</td>
+            </tr>
+            <tr>
+              <td>
+                <code>Tab</code> and <code>Shift+Tab</code>
+              </td>
+              <td>Move cursor to first unfilled square of next or previous unfilled clue</td>
+            </tr>
+            <tr>
+              <td>
+                <code>Delete</code> or <code>Backspace</code>
+              </td>
+              <td>Clear current cell</td>
+            </tr>
+          </table>
         </Popup>
       </div>
     );

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -3,6 +3,7 @@ import React, {Component} from 'react';
 
 import Clock from './Clock';
 import ActionMenu from './ActionMenu';
+import Popup from './Popup';
 import Flex from 'react-flexview';
 import {Link} from 'react-router-dom';
 
@@ -126,6 +127,24 @@ export default class Toolbar extends Component {
     );
   }
 
+  renderInfo() {
+    return (
+      <div className={'toolbar--info'}>
+        <Popup icon="fa-info-circle" onBlur={this.handleBlur}>
+          <strong>How to Enter Answers:</strong>
+          <ul>
+            <li>
+              You can click a square once to enter an answer, and click that same square again to switch
+              between a down or across for that square
+            </li>
+            <li>You can also click the questions to go straight to answering them</li>
+            <li>You can hold down the shift key to enter multiple characters for rebus answers</li>
+          </ul>
+        </Popup>
+      </div>
+    );
+  }
+
   check(scopeString) {
     this.props.onCheck(scopeString);
   }
@@ -185,6 +204,7 @@ export default class Toolbar extends Component {
         {solved ? null : this.renderRevealMenu()}
         <div className="toolbar--menu reset">{this.renderResetMenu()}</div>
         {this.renderPencil()}
+        {this.renderInfo()}
       </div>
     );
   }


### PR DESCRIPTION
**What**
Basing off of a discussion had on #85 I realized it might be nice to have instructions on how to use the app for future people curious on how to answer rebuses. This PR makes a modal for instructions on app usage and [specifically calls out the rebus functionality](https://github.com/downforacross/downforacross.com/compare/master...ibrand:info-button-with-instructions?expand=1#diff-03812c996752ae5efb2018ea2f2fc260R141).

Happy to make changes to this or for you to just take inspiration for it if you want to add something else.

**Screenshot of functionality:**
<img width="1440" alt="Screen Shot 2020-04-04 at 2 38 07 PM" src="https://user-images.githubusercontent.com/3953117/78458769-ebf85280-7681-11ea-87b1-7ddb253e49dd.png">
