### PR TITLE
Fix issue where mobile chat didn't bring up a keyboard.

### DIFF
--- a/src/components/Chat/ChatBar.js
+++ b/src/components/Chat/ChatBar.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import EmojiPicker from './EmojiPicker';
 import * as emojiLib from '../../lib/emoji';
-import EditableSpan from '../common/EditableSpan';
 
 const MAX_EMOJIS = 150;
 export default class ChatBar extends React.Component {
@@ -114,25 +113,10 @@ export default class ChatBar extends React.Component {
   }
 
   renderInput() {
-    if (this.props.mobile) {
-      return (
-        <div>
-          <EditableSpan
-            mobile={this.props.mobile}
-            value={this.state.message}
-            key_={this.state.enters}
-            onChange={this.handleChangeMobile}
-            onPressEnter={this.handlePressEnter}
-            style={{height: 24}}
-            containerStyle={{display: 'block'}}
-          />
-        </div>
-      );
-    }
     return (
       <input
         ref={this.input}
-        className="chat--bar--input"
+        className={this.props.mobile ? 'chat--bar--input--mobile' : 'chat--bar--input'}
         placeholder="[Enter] to chat"
         value={this.state.message}
         onChange={this.handleChange}

--- a/src/components/Chat/css/index.css
+++ b/src/components/Chat/css/index.css
@@ -120,3 +120,10 @@
 .chat--bar--input {
   width: 100%;
 }
+
+.chat--bar--input--mobile {
+  width: 100%;
+  border: 1px solid #dddddd;
+  height: 24px;
+  font-size: 14px;
+}


### PR DESCRIPTION
Looks like this was from when we removed the custom mobile
keyboard, but didn't make sure the default keyboard would
get rendered instead.

This just subs the mobile EditableSpan with a regular old
input. Except I added some styling to keep it more
consistent with how the current mobile chat input looks.

![image](https://user-images.githubusercontent.com/16993553/81466205-86b5e680-9184-11ea-961c-90da4607ead7.png)
