### PR TITLE
Mobile UI improvements + Material icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-flexview": "^3.0.1",
     "react-fontawesome": "^1.6.1",
     "react-helmet": "^5.2.0",
+    "react-icons": "^3.10.0",
     "react-router-dom": "^4.1.2",
     "react-simple-keyboard": "^1.15.2",
     "react-timestamp": "^4.4.0",

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -9,6 +9,7 @@ import _ from 'lodash';
 import MobileKeyboard from '../Player/MobileKeyboard';
 import Flex from 'react-flexview';
 import {Link} from 'react-router-dom';
+import {MdClose} from 'react-icons/md';
 
 const isEmojis = (str) => {
   const res = str.match(/[A-Za-z,.0-9!-]/g);
@@ -98,19 +99,7 @@ export default class Chat extends Component {
   }
 
   renderGameButton() {
-    return (
-      <svg
-        onClick={this.handleToggleChat}
-        className="toolbar--game"
-        viewBox="0 0 90 90"
-        enableBackground="0 0 90 90"
-        space="preserve"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlnsXlink="http://www.w3.org/1999/xlink"
-      >
-        <path d="M72.55664,51.2041c3.0874-3.93164,4.87598-8.56836,4.87598-13.53711c0-14.18066-14.52051-25.67578-32.43262-25.67578  S12.56738,23.48633,12.56738,37.66699c0,14.17969,14.52051,25.67578,32.43262,25.67578c2.61572,0,5.15625-0.25195,7.59277-0.71484  v15.38086L72.55664,51.2041z" />
-      </svg>
-    );
+    return <MdClose onClick={this.handleToggleChat} className="toolbar--game" />;
   }
 
   renderToolbar() {

--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -480,7 +480,6 @@ export default class MobileGridControls extends GridControls {
       <div ref="gridControls" className="mobile-grid-controls">
         {this.renderClueBar()}
         {this.renderGridContent()}
-        {this.renderClueBar()}
         {this.renderMobileInputs()}
         {/* {this.renderMobileKeyboard()} */}
         {this.props.enableDebug && (this.state.dbgstr || 'No message')}

--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -2,6 +2,7 @@ import './css/mobileGridControls.css';
 
 import React from 'react';
 import Flex from 'react-flexview';
+import {MdKeyboardArrowLeft, MdKeyboardArrowRight} from 'react-icons/md';
 import Clue from './ClueText';
 import GridControls from './GridControls';
 import MobileKeyboard from './MobileKeyboard';
@@ -337,13 +338,11 @@ export default class MobileGridControls extends GridControls {
     };
     return (
       <Flex className="mobile-grid-controls--clue-bar-container">
-        <div
+        <MdKeyboardArrowLeft
           className="mobile-grid-controls--intra-clue left"
           onTouchEnd={this.handleLeftArrowTouchEnd}
           onClick={this.keepFocus}
-        >
-          {'<'}
-        </div>
+        />
         <Flex
           grow={1}
           vAlignContent="center"
@@ -372,13 +371,11 @@ export default class MobileGridControls extends GridControls {
             </div>
           </div>
         </Flex>
-        <div
+        <MdKeyboardArrowRight
           className="mobile-grid-controls--intra-clue left"
           onClick={this.keepFocus}
           onTouchEnd={this.handleRightArrowTouchEnd}
-        >
-          {'>'}
-        </div>
+        />
       </Flex>
     );
   }

--- a/src/components/Player/css/mobileGridControls.css
+++ b/src/components/Player/css/mobileGridControls.css
@@ -30,7 +30,11 @@
 
 .mobile-grid-controls--intra-clue {
   background-color: var(--main-blue-3);
-  padding: 20px;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .mobile-grid-controls--clue-bar {

--- a/src/components/Player/css/mobileGridControls.css
+++ b/src/components/Player/css/mobileGridControls.css
@@ -30,8 +30,9 @@
 
 .mobile-grid-controls--intra-clue {
   background-color: var(--main-blue-3);
-  width: 48px;
-  height: 48px;
+  width: 24px;
+  height: 24px;
+  padding: 12px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/PuzzleList/Entry.js
+++ b/src/components/PuzzleList/Entry.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import _ from 'lodash';
 import Flex from 'react-flexview';
-import FontAwesome from 'react-fontawesome';
+import {MdRadioButtonUnchecked, MdCheckCircle} from 'react-icons/md';
 import {Link} from 'react-router-dom';
 
 export default class Entry extends Component {
@@ -42,7 +42,6 @@ export default class Entry extends Component {
   render() {
     const {title, author, pid, status, stats = {}} = this.props;
     const numSolves = _.size(stats.solves);
-    const faName = status === 'started' ? 'circle-o' : status === 'solved' ? 'check-circle' : '';
     return (
       <Link to={`/beta/play/${pid}`} style={{textDecoration: 'none', color: 'initial'}}>
         <Flex className="entry" column onClick={this.handleClick} onMouseLeave={this.handleMouseLeave}>
@@ -55,8 +54,9 @@ export default class Entry extends Component {
                 {author} | {this.size}
               </p>
             </Flex>
-            <Flex className="entry--icon">
-              <FontAwesome name={faName} style={{color: '#6AA9F4'}} />
+            <Flex>
+              {status === 'started' && <MdRadioButtonUnchecked className="entry--icon" />}
+              {status === 'solved' && <MdCheckCircle className="entry--icon" />}
             </Flex>
           </Flex>
           <Flex className="entry--main">

--- a/src/components/PuzzleList/css/puzzleList.css
+++ b/src/components/PuzzleList/css/puzzleList.css
@@ -3,6 +3,10 @@
   margin-top: 25px;
 }
 
+.entry--icon {
+  fill: #6aa9f4;
+}
+
 .mobile .entry--container {
   margin: 18px auto 0;
 }

--- a/src/components/Toolbar/css/ActionMenu.css
+++ b/src/components/Toolbar/css/ActionMenu.css
@@ -26,7 +26,7 @@
 
 .action-menu--list--action {
   text-align: left;
-  padding: 15px;
+  padding: 16px;
   border-left: 1px solid var(--main-gray-2);
   border-bottom: 1px solid var(--main-gray-2);
   border-right: 1px solid var(--main-gray-2);
@@ -39,5 +39,6 @@
 }
 
 .toolbar--mobile--top .action-menu--list--action {
-  padding: 5px;
+  box-sizing: border-box;
+  height: 48px;
 }

--- a/src/components/Toolbar/css/index.css
+++ b/src/components/Toolbar/css/index.css
@@ -27,21 +27,21 @@ code {
 }
 
 .toolbar--chat {
-  width: 30px;
-  height: 30px;
+  width: 24px;
+  height: 24px;
+  padding: 12px;
   fill: white;
-  margin-right: 23px;
 }
 
 .toolbar--game {
-  width: 30px;
-  height: 30px;
-  fill: black;
-  margin-right: 23px;
+  width: 24px;
+  height: 24px;
+  padding: 12px;
+  fill: white;
 }
 
 .toolbar--mobile a {
-  margin-left: 25px;
+  margin-left: 16px;
   color: white;
   text-decoration: none;
   font-weight: 600;
@@ -50,9 +50,10 @@ code {
 .toolbar--mobile button {
   background-color: transparent;
   border: none;
-  padding: 7px;
+  padding: 16px;
   color: white;
   font-size: 14px;
+  height: 48px;
 }
 
 .toolbar button {

--- a/src/components/Toolbar/css/index.css
+++ b/src/components/Toolbar/css/index.css
@@ -20,10 +20,10 @@ code {
 }
 
 .toolbar--mobile {
-  height: 52px;
-  max-height: 52px;
+  height: 48px;
   background-color: var(--main-blue);
   justify-content: space-between;
+  font-size: 14px;
 }
 
 .toolbar--chat {
@@ -45,7 +45,6 @@ code {
   color: white;
   text-decoration: none;
   font-weight: 600;
-  font-size: 17px;
 }
 
 .toolbar--mobile button {
@@ -53,12 +52,11 @@ code {
   border: none;
   padding: 7px;
   color: white;
-  font-size: 11px;
+  font-size: 14px;
 }
 
 .toolbar button {
   color: var(--main-gray-1);
-  font-size: 14px;
   padding: 7px 10px 7px 10px;
   border-radius: 5px;
   background-color: white;
@@ -91,7 +89,6 @@ code {
 }
 
 .toolbar--mobile--top {
-  font-size: 15px;
   justify-content: space-between;
   align-items: center;
   position: relative;

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -216,7 +216,7 @@ export default class Toolbar extends Component {
       return (
         <Flex className="toolbar--mobile" vAlignContent="center">
           <Flex className="toolbar--mobile--top" grow={1} vAlignContent="center">
-            <Link to={'/'}>Down for a Cross</Link>{' '}
+            <Link to={'/'}>DFAC</Link>{' '}
             <Clock
               v2={this.props.v2}
               startTime={startTime}

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -1,5 +1,6 @@
 import './css/index.css';
 import React, {Component} from 'react';
+import {MdChatBubble} from 'react-icons/md';
 
 import Clock from './Clock';
 import ActionMenu from './ActionMenu';
@@ -97,20 +98,7 @@ export default class Toolbar extends Component {
   }
 
   renderChatButton() {
-    return (
-      <svg
-        onClick={this.handleToggleChat}
-        className="toolbar--chat"
-        viewBox="0 0 90 90"
-        enableBackground="0 0 90 90"
-        space="preserve"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlnsXlink="http://www.w3.org/1999/xlink"
-      >
-        <path d="M72.55664,51.2041c3.0874-3.93164,4.87598-8.56836,4.87598-13.53711c0-14.18066-14.52051-25.67578-32.43262-25.67578  S12.56738,23.48633,12.56738,37.66699c0,14.17969,14.52051,25.67578,32.43262,25.67578c2.61572,0,5.15625-0.25195,7.59277-0.71484  v15.38086L72.55664,51.2041z" />
-        {this.props.unreads && <circle stroke="none" fill="red" cx="70" cy="20" r="20" />}
-      </svg>
-    );
+    return <MdChatBubble onClick={this.handleToggleChat} className="toolbar--chat" />;
   }
 
   renderPencil() {

--- a/src/components/Upload/FileUploader.js
+++ b/src/components/Upload/FileUploader.js
@@ -2,6 +2,7 @@ import './css/fileUploader.css';
 
 import React, {Component} from 'react';
 import Dropzone from 'react-dropzone';
+import {MdFileUpload} from 'react-icons/md';
 
 import {hasShape} from '../../lib/jsUtils';
 import PUZtoJSON from '../../lib/converter/PUZtoJSON';
@@ -79,15 +80,7 @@ export default class FileUploader extends Component {
       >
         <div className={`file-uploader--wrapper ${v2 ? 'v2' : ''}`}>
           <div className="file-uploader--box">
-            <svg
-              className="file-uploader--box--icon"
-              xmlns="http://www.w3.org/2000/svg"
-              width="50"
-              height="43"
-              viewBox="0 0 50 43"
-            >
-              <path d="M48.4 26.5c-.9 0-1.7.7-1.7 1.7v11.6h-43.3v-11.6c0-.9-.7-1.7-1.7-1.7s-1.7.7-1.7 1.7v13.2c0 .9.7 1.7 1.7 1.7h46.7c.9 0 1.7-.7 1.7-1.7v-13.2c0-1-.7-1.7-1.7-1.7zm-24.5 6.1c.3.3.8.5 1.2.5.4 0 .9-.2 1.2-.5l10-11.6c.7-.7.7-1.7 0-2.4s-1.7-.7-2.4 0l-7.1 8.3v-25.3c0-.9-.7-1.7-1.7-1.7s-1.7.7-1.7 1.7v25.3l-7.1-8.3c-.7-.7-1.7-.7-2.4 0s-.7 1.7 0 2.4l10 11.6z" />
-            </svg>
+            <MdFileUpload className="file-uploader--box--icon" />
             Import .puz file
           </div>
         </div>

--- a/src/components/Upload/css/fileUploader.css
+++ b/src/components/Upload/css/fileUploader.css
@@ -13,6 +13,7 @@
 }
 
 .file-uploader--box {
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -21,11 +22,10 @@
 }
 
 .file-uploader--box--icon {
+  width: 72px;
+  height: 72px;
   fill: var(--main-blue);
-  cursor: pointer;
-  text-align: center;
-  margin-top: 40px;
-  margin-bottom: 60px;
+  margin: 24px;
 }
 
 .file-uploader--wrapper.v2 {

--- a/src/pages/Welcome.js
+++ b/src/pages/Welcome.js
@@ -3,7 +3,7 @@ import './css/welcome.css';
 import React, {Component} from 'react';
 import {Helmet} from 'react-helmet';
 import Flex from 'react-flexview';
-import {MdSearch} from 'react-icons/md';
+import {MdSearch, MdCheckBoxOutlineBlank, MdCheckBox} from 'react-icons/md';
 import _ from 'lodash';
 import Nav from '../components/common/Nav';
 import Upload from '../components/Upload';
@@ -229,8 +229,12 @@ export default class Welcome extends Component {
                 handleChange(header, name, e.target.checked);
               }}
             />
-            <div className="checkmark" />
-            {name}
+            {items[name] ? (
+              <MdCheckBox className="checkbox-icon" />
+            ) : (
+              <MdCheckBoxOutlineBlank className="checkbox-icon" />
+            )}
+            <span>{name}</span>
           </label>
         ))}
       </Flex>

--- a/src/pages/Welcome.js
+++ b/src/pages/Welcome.js
@@ -3,6 +3,7 @@ import './css/welcome.css';
 import React, {Component} from 'react';
 import {Helmet} from 'react-helmet';
 import Flex from 'react-flexview';
+import {MdSearch} from 'react-icons/md';
 import _ from 'lodash';
 import Nav from '../components/common/Nav';
 import Upload from '../components/Upload';
@@ -286,13 +287,6 @@ export default class Welcome extends Component {
     };
   }
 
-  get iconStyle() {
-    return {
-      position: 'absolute',
-      left: '10px',
-    };
-  }
-
   get searchIconGraphicsStyle() {
     if (!this.mobile) return undefined;
     const stroke = colorAverage(BLUE, WHITE, this.colorMotion);
@@ -311,14 +305,7 @@ export default class Welcome extends Component {
     const {search} = this.state;
     const hAlignContent = this.mobile ? 'right' : 'left';
     const grow = this.mobile ? 0 : 1;
-    const searchIcon = (
-      <div className="welcome--searchicon">
-        <svg viewBox="0 0 40 40">
-          <circle cx={20} cy={20} r={15} style={this.searchIconGraphicsStyle} />
-          <line x1={30} y1={30} x2={40} y2={40} style={this.searchIconGraphicsStyle} />
-        </svg>
-      </div>
-    );
+    const searchIcon = <MdSearch className="welcome--searchicon" />;
     return (
       <Flex className="welcome--searchbar--container" shrink={0} hAlignContent={hAlignContent}>
         <Flex
@@ -327,9 +314,7 @@ export default class Welcome extends Component {
           grow={grow}
           className="welcome--searchbar--wrapper"
         >
-          <div style={this.iconStyle} onTouchEnd={this.handleSearchIconTouchEnd}>
-            {searchIcon}
-          </div>
+          <MdSearch className="welcome--searchicon" onTouchEnd={this.handleSearchIconTouchEnd} />
           <input
             ref={this.searchInput}
             style={this.searchInputStyle}

--- a/src/pages/css/welcome.css
+++ b/src/pages/css/welcome.css
@@ -87,41 +87,23 @@
 .filters label {
   position: relative;
   cursor: pointer;
-  line-height: 1.8;
+  line-height: 24px;
+  margin: 4px 0;
 }
 
-.filters .checkmark {
-  background-color: white !important;
-  border-radius: 3px;
-  border: 1px solid silver;
-  display: inline-block;
-  height: 15px;
-  margin-right: 10px;
-  position: relative;
-  top: 3px;
-  width: 15px;
+.checkbox-icon {
+  float: left;
+  width: 24px;
+  height: 24px;
+  fill: #6aa9f4;
+  margin-right: 8px;
 }
 
 .filters input {
-  width: 0px;
+  width: 24px;
+  height: 24px;
+  position: absolute;
   opacity: 0;
-}
-
-.filters input:checked ~ .checkmark:after {
-  content: '';
-  /* drawing a "checkmark" with css */
-  /* https://www.w3schools.com/howto/howto_css_custom_checkbox.asp */
-  position: relative;
-  left: 8.5px;
-  top: -4px;
-  width: 4px;
-  height: 12px;
-  border: solid #6aa9f4;
-  border-width: 0 4px 4px 0;
-  -webkit-transform: rotate(45deg);
-  -ms-transform: rotate(45deg);
-  transform: rotate(45deg);
-  display: block;
 }
 
 .quickplay {

--- a/src/pages/css/welcome.css
+++ b/src/pages/css/welcome.css
@@ -76,17 +76,12 @@
   position: relative;
 }
 
-.welcome--searchicon svg circle,
-.welcome--searchicon svg line {
-  stroke: var(--main-blue);
-  stroke-width: 5px;
-  fill: none;
-}
-
 .welcome--searchicon {
   color: var(--main-blue);
-  height: 20px;
-  width: 20px;
+  height: 24px;
+  width: 24px;
+  padding: 8px;
+  position: absolute;
 }
 
 .filters label {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11925,6 +11925,13 @@ react-helmet@^5.2.0:
     prop-types "^15.5.4"
     react-side-effect "^1.1.0"
 
+react-icons@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.10.0.tgz#6c217a2dde2e8fa8d293210023914b123f317297"
+  integrity sha512-WsQ5n1JToG9VixWilSo1bHv842Cj5aZqTGiS3Ud47myF6aK7S/IUY2+dHcBdmkQcCFRuHsJ9OMUI0kTDfjyZXQ==
+  dependencies:
+    camelcase "^5.0.0"
+
 react-is@^16.12.0, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
- Size mobile toolbars for touch targets (≥ 48px)
- Remove second clue bar on mobile (is there a reason for it?)
- Replace most icons with [Material icon set](https://material.io/resources/icons/?style=baseline) to improve visuals and simplify code

![desktop-home](https://user-images.githubusercontent.com/345452/82162046-7245ae00-9856-11ea-85f5-97d8a4b7df16.png)
![mobile-chat](https://user-images.githubusercontent.com/345452/82162048-74a80800-9856-11ea-934e-e107699d8ca9.png)
![mobile-home](https://user-images.githubusercontent.com/345452/82162049-75409e80-9856-11ea-8ece-cb37ceb8b304.png)
![mobile-puzzle](https://user-images.githubusercontent.com/345452/82162051-75d93500-9856-11ea-9075-cbea06a5abb4.png)
