### PR TITLE
Use a tokenizing filter

### DIFF
--- a/src/components/PuzzleList/PuzzleList.js
+++ b/src/components/PuzzleList/PuzzleList.js
@@ -80,10 +80,11 @@ export default class PuzzleList extends PureComponent {
     const searchMatches = search
       .toLowerCase()
       .split(/\s/)
-      .every((token) => {
-        // Each token can be either in the author's name or in the puzzle's title
-        author.includes(token) || title.includes(token);
-      });
+      .every(
+        (token) =>
+          // Each token can be either in the author's name or in the puzzle's title
+          author.includes(token) || title.includes(token)
+      );
 
     return statusFilter[status] && sizeFilter[size] && searchMatches;
   };

--- a/src/components/PuzzleList/PuzzleList.js
+++ b/src/components/PuzzleList/PuzzleList.js
@@ -73,16 +73,18 @@ export default class PuzzleList extends PureComponent {
       started: 'In progress',
     }[this.puzzleStatuses[entry.pid]];
 
-    const matches = (str, expr) => {
-      if (expr.toLowerCase() === expr) {
-        // case insensitive
-        return str.toLowerCase().indexOf(expr) !== -1;
-      } else {
-        // case sensitive
-        return str.indexOf(expr) !== -1;
-      }
-    };
-    const searchMatches = matches(entry.info.author, search) || matches(entry.info.title, search);
+    // Normalise case, and do it outside the filter loop for performance reasons
+    const author = entry.info.author.toLowerCase();
+    const title = entry.info.title.toLowerCase();
+    // Next, we normalise the search term, and then split it to allow for non-contiguous searches
+    const searchMatches = search
+      .toLowerCase()
+      .split(/\s/)
+      .every((token) => {
+        // Each token can be either in the author's name or in the puzzle's title
+        author.includes(token) || title.includes(token);
+      });
+
     return statusFilter[status] && sizeFilter[size] && searchMatches;
   };
 


### PR DESCRIPTION
Instead of the current (confusing) filter behaviour, we instead:

* Lower case the search string
* Split it into tokens

Then, each token must be present within the (lowercase) author name, or puzzle title or it is filtered out.

This is a draft PR until I can actually test it (see #116)

Closes #92.