### PR TITLE
Unify font styling across app and light and dark themes

### DIFF
--- a/src/dark.css
+++ b/src/dark.css
@@ -107,9 +107,6 @@
   background-color: #111;
   color: #ccc;
   border-color: #ccc;
-  border-left: none;
-  border-top: none;
-  border-right: none;
   outline: none;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -5,6 +5,8 @@ html {
 
 html,
 body,
+input,
+button,
 #root,
 .router-wrapper {
   display: flex;


### PR DESCRIPTION
Makes use of the same font family in the search bar, chat, and buttons. Arial (or the default input font on a browser) is too noticeable among the various text renderings.

Makes dark theme use the same outline shape on inputs for consistency. This makes the full bounding box seen on dark theme (in line with the light theme).