### PR TITLE
optimize puzzlelist: page geometrically instead of linearly

### DIFF
--- a/src/pages/Welcome.js
+++ b/src/pages/Welcome.js
@@ -71,16 +71,16 @@ export default class Welcome extends Component {
   }
 
   nextPage = () => {
-    const {pages} = this.state;
     if (this.loading || this.done) {
       return;
     }
     this.loading = true;
-    this.puzzleList.getPages(pages + 10, (page) => {
+    const nextPages = this.state.pages * 2 + 1; // double the number of pages loaded every time
+    this.puzzleList.getPages(nextPages, (page) => {
       this.setState(
         {
           puzzles: page,
-          pages: pages + 10,
+          pages: nextPages,
         },
         () => {
           this.loading = false;

--- a/src/pages/Welcome.js
+++ b/src/pages/Welcome.js
@@ -76,11 +76,11 @@ export default class Welcome extends Component {
       return;
     }
     this.loading = true;
-    this.puzzleList.getPages(pages + 1, (page) => {
+    this.puzzleList.getPages(pages + 10, (page) => {
       this.setState(
         {
           puzzles: page,
-          pages: pages + 1,
+          pages: pages + 10,
         },
         () => {
           this.loading = false;


### PR DESCRIPTION
Embarassingly, searching the puzzle repo accounts for a huge amount of the hosting costs of downforacross. this change should drastically reduce the amount of data being read from firebase.
 

---

the entire puzzle list is about 3MB, with ~10000 entries. The algorithm for search often behaves extremely inefficiently, because 
1. client-side filters the puzzle list items
2. fetches the last 1 page, then last 2 pages, then last 3 pages, until it has enough post-filter results to render the page up to where the user has scrolled to.

In total this means that doing a single search for a keyword like "foobar" will cause the client to download the entire puzzle list 10000 / 40 = 250 times, for a total of 600MB data transferred.

This PR reduces that worst case behavior to ~6MB (100x) by doubling the number of pages loaded every time, resulting in the number of MB being downloaded in successive queries to form a geometric series with sum bounded by ~2x the size of the total repo.

![image](https://user-images.githubusercontent.com/1988030/103200054-3faa6c00-48a1-11eb-8cc5-baaf6ef26793.png)
