### PR TITLE
make puzzle repo not all get downloaded

### DIFF
--- a/src/store/puzzlelist.js
+++ b/src/store/puzzlelist.js
@@ -10,6 +10,7 @@ export default class Puzzlelist extends EventEmitter {
   }
 
   getPages(pages, cbk) {
+    pages = Math.min(pages, 50);
     return this.ref
       .orderByKey()
       .limitToLast(pages * this.pageSize)

--- a/src/store/puzzlelist.js
+++ b/src/store/puzzlelist.js
@@ -10,7 +10,7 @@ export default class Puzzlelist extends EventEmitter {
   }
 
   getPages(pages, cbk) {
-    pages = Math.min(pages, 50);
+    pages = Math.min(pages, 100);
     return this.ref
       .orderByKey()
       .limitToLast(pages * this.pageSize)


### PR DESCRIPTION
a follow-up to https://github.com/downforacross/downforacross.com/pull/134, no one really needs more than the latest 4000 puzzles. at least for now.