### PR TITLE
support room ids

### DIFF
--- a/server/model/room.ts
+++ b/server/model/room.ts
@@ -7,7 +7,7 @@ export async function getRoomEvents(rid: string) {
   const res = await pool.query('SELECT event_payload FROM room_events WHERE rid=$1', [rid]);
   const events = _.map(res.rows, 'event_payload');
   const ms = Date.now() - startTime;
-  console.log(`getEvents(${rid}) took ${ms}ms`);
+  console.log(`getRoomEvents(${rid}) took ${ms}ms`);
   return events;
 }
 

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -3,12 +3,26 @@ import _ from 'lodash';
 import {Helmet} from 'react-helmet';
 import {RouteComponentProps} from 'react-router';
 
-import {RoomEvent, UserPingRoomEvent} from '../shared/roomEvents';
+import {RoomEvent, SetGameRoomEvent, UserPingRoomEvent} from '../shared/roomEvents';
 import {useSocket} from '../sockets/useSocket';
 import {initialRoomState, roomReducer} from '../lib/reducers/room';
 import {emitAsync} from '../sockets/emitAsync';
-import {useMount} from 'react-use';
+import {makeStyles} from '@material-ui/core';
 
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    height: '100%',
+    flexDirection: 'column',
+  },
+  content: {
+    flex: 1,
+    '& iframe': {
+      width: '100%',
+      height: '100%',
+    },
+  },
+});
 function subscribeToRoomEvents(
   socket: SocketIOClient.Socket | undefined,
   rid: string,
@@ -55,6 +69,12 @@ const Room: React.FC<RouteComponentProps<{rid: string}>> = (props) => {
       emitAsync(socket, 'room_event', {rid, event});
     }
   }
+  async function setGame(gid: string) {
+    if (socket) {
+      const event = SetGameRoomEvent(gid);
+      emitAsync(socket, 'room_event', {rid, event});
+    }
+  }
   useEffect(() => {
     setEvents([]);
     const {syncPromise, unsubscribe} = subscribeToRoomEvents(socket, rid, setEvents);
@@ -70,15 +90,28 @@ const Room: React.FC<RouteComponentProps<{rid: string}>> = (props) => {
       window.removeEventListener('keydown', renewActivity);
     };
   }, [rid, socket]);
+  const handleAddGame = () => {
+    const gameLink = window.prompt('Enter game link');
+    const gid = _.last(gameLink?.split('/'));
+    console.log(gid);
+    if (gid && gid.match('[a-z0-9-]{1,15}')) {
+      setGame(gid);
+    }
+  };
+  const classes = useStyles();
+  const currentGame = _.last(roomState.games);
   return (
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-      }}
-    >
+    <div className={classes.container}>
       <Helmet title={`Room ${rid}`} />
-      <div>{roomState.users.length} users here</div>
+      <div>{roomState.users.length} users</div>
+      {currentGame && <div>Current game: {currentGame.gid}</div>}
+      <div>
+        <button onClick={handleAddGame}>Change game</button>
+      </div>
+      <div className={classes.content}>
+        {currentGame && <iframe src={`/game/${currentGame.gid}`} />}
+        {!currentGame && <div>No game selected!</div>}
+      </div>
     </div>
   );
 };

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -9,6 +9,8 @@ import {initialRoomState, roomReducer} from '../lib/reducers/room';
 import {emitAsync} from '../sockets/emitAsync';
 import {makeStyles} from '@material-ui/core';
 
+const ACTIVE_SECONDS_TIMEOUT = 60;
+
 const useStyles = makeStyles({
   container: {
     display: 'flex',
@@ -18,8 +20,26 @@ const useStyles = makeStyles({
   content: {
     flex: 1,
     '& iframe': {
+      border: 'none',
       width: '100%',
       height: '100%',
+    },
+  },
+  totalUsersParen: {
+    color: '#DDDDDD',
+  },
+  footer: {
+    padding: 12,
+    display: 'flex',
+    justifyContent: 'space-between',
+    background: 'var(--main-blue)',
+    color: '#FBFBFB',
+    '& button': {
+      border: 'none',
+      background: 'none',
+      outline: '1px solid',
+      color: '#FBFBFB',
+      cursor: 'pointer',
     },
   },
 });
@@ -55,14 +75,25 @@ function useRoomState(events: RoomEvent[]) {
   return useMemo(() => events.reduce(roomReducer, initialRoomState), [events]);
 }
 
+const useTimer = (interval = 1000): number => {
+  const [time, setTime] = useState(Date.now());
+  useEffect(() => {
+    const itvl = setInterval(() => {
+      setTime(Date.now());
+    }, interval);
+    return () => {
+      clearInterval(itvl);
+    };
+  }, []);
+  return time;
+};
+
 const Room: React.FC<RouteComponentProps<{rid: string}>> = (props) => {
   const rid = props.match.params.rid;
   const socket = useSocket();
   const [events, setEvents] = useState<RoomEvent[]>([]);
-  console.log('events is', events);
   const roomState = useRoomState(events);
 
-  console.log('room state is', roomState);
   async function sendUserPing() {
     if (socket) {
       const event = UserPingRoomEvent();
@@ -82,7 +113,7 @@ const Room: React.FC<RouteComponentProps<{rid: string}>> = (props) => {
     return unsubscribe;
   }, [rid, socket]);
   useEffect(() => {
-    const renewActivity = _.throttle(sendUserPing, 1000 * 60);
+    const renewActivity = _.throttle(sendUserPing, 1000 * 10);
     window.addEventListener('mousemove', renewActivity);
     window.addEventListener('keydown', renewActivity);
     return () => {
@@ -91,26 +122,34 @@ const Room: React.FC<RouteComponentProps<{rid: string}>> = (props) => {
     };
   }, [rid, socket]);
   const handleAddGame = () => {
-    const gameLink = window.prompt('Enter game link');
+    const gameLink = window.prompt('Enter new game link');
     const gid = _.last(gameLink?.split('/'));
-    console.log(gid);
     if (gid && gid.match('[a-z0-9-]{1,15}')) {
       setGame(gid);
     }
   };
+  const currentTime = useTimer();
   const classes = useStyles();
   const currentGame = _.first(roomState.games);
   return (
     <div className={classes.container}>
       <Helmet title={`Room ${rid}`} />
-      <div>{roomState.users.length} users</div>
-      {currentGame && <div>Current game: {currentGame.gid}</div>}
-      <div>
-        <button onClick={handleAddGame}>Change game</button>
-      </div>
       <div className={classes.content}>
         {currentGame && <iframe src={`/game/${currentGame.gid}`} />}
         {!currentGame && <div>No game selected!</div>}
+      </div>
+      <div className={classes.footer}>
+        <div>
+          In this room:{' '}
+          {
+            _.filter(roomState.users, (user) => user.lastPing > currentTime - ACTIVE_SECONDS_TIMEOUT * 1000)
+              .length
+          }{' '}
+          <span className={classes.totalUsersParen}>({roomState.users.length} total)</span>
+        </div>
+        <div>
+          <button onClick={handleAddGame}>Game: {currentGame?.gid ?? 'N/A'}</button>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -99,7 +99,7 @@ const Room: React.FC<RouteComponentProps<{rid: string}>> = (props) => {
     }
   };
   const classes = useStyles();
-  const currentGame = _.last(roomState.games);
+  const currentGame = _.first(roomState.games);
   return (
     <div className={classes.container}>
       <Helmet title={`Room ${rid}`} />

--- a/src/shared/roomEvents.ts
+++ b/src/shared/roomEvents.ts
@@ -2,11 +2,15 @@ import {getUser} from '../store/user';
 
 export enum RoomEventType {
   USER_PING = 'USER_PING',
+  SET_GAME = 'SET_GAME',
 }
 
 export interface RoomEventParams {
   [RoomEventType.USER_PING]: {
     uid: string;
+  };
+  [RoomEventType.SET_GAME]: {
+    gid: string;
   };
 }
 
@@ -25,3 +29,20 @@ export const UserPingRoomEvent = (): RoomEvent<RoomEventType.USER_PING> => ({
     uid: getUser().id,
   },
 });
+
+export const isUserPingEvent = (event: RoomEvent): event is RoomEvent<RoomEventType.USER_PING> => {
+  return event.type === RoomEventType.USER_PING;
+};
+
+export const SetGameRoomEvent = (gid: string): RoomEvent<RoomEventType.SET_GAME> => ({
+  timestamp: Date.now(),
+  type: RoomEventType.SET_GAME,
+  uid: getUser().id,
+  params: {
+    gid,
+  },
+});
+
+export const isSetGameEvent = (event: RoomEvent): event is RoomEvent<RoomEventType.SET_GAME> => {
+  return event.type === RoomEventType.SET_GAME;
+};

--- a/src/style.css
+++ b/src/style.css
@@ -6,12 +6,16 @@ html {
 html,
 body,
 input,
-button,
 #root,
 .router-wrapper {
   display: flex;
   flex-direction: column;
   flex: 1;
+  margin: 0;
+  font-family: 'avenir next', avenir, 'Nunito', 'helvetica neue', 'Helvetica', 'arial', sans-serif;
+}
+
+button {
   margin: 0;
   font-family: 'avenir next', avenir, 'Nunito', 'helvetica neue', 'Helvetica', 'arial', sans-serif;
 }


### PR DESCRIPTION
the vision for rooms
- a permanent link that can hold multiple games -- so when you're done and want to play a new game, you don't need to paste a new link for everyone to join.

some immediate things that this unblocks
- users can bookmark a link like downforacross.com/team/stevens-crossword-friends-1
- gather.town integration
- public lobby rooms for people to meet other users on the platform. can link to these in homepage / pin to discord or whatever
- an archive of puzzles that a group has solved together

---


this pr might be broken into multiple PRs to allow incremental progress:
- [x] define backend schema, create table in staging: https://github.com/downforacross/downforacross.com/pull/143
- [x] support lazy creation of rooms (provide a name in the URL) + extend websocket setup to support room events. see "room actions" section below: https://github.com/downforacross/downforacross.com/pull/144
- [ ] support creating games within a room (appends to a room's list of games) and playing a game within a room [this PR]
- [ ] support listing games within a room (render a list of game names, number of ppl in game, last updated date)
- [ ] support playing games within a room (select which game to join,
      auto-join last game when join)

Room actions to support:
- addGame(gid) -- add gid to list of games that belong to this room.
  - note: allows multiple rooms to share the same game. whatever.
- updateProgress(gid, status) -- indicate that you are active in game gid, and
game has progress = { percentComplete, isComplete, numEdits, numActions }
  - note: progress tracking is denormalized (done via client), slightly hacky. can iterate on this in future if it turns out to be troublesome

Room should be implemented in the same way as games -- events &
reducers, synchronized via ws
- although the current schema of room events is dead simple, it may
become more complex in the future, and synchronizing an append-only list of events is
easier than synchronizing any other data structure.

Custom room ui
- new url -- /room/:rid
- within the room: render a `RoomSidebar` component on the left
  - collapsible
  - view games belonging to room + their progress & number of active
  users
  - a room sidebarrender a list of puzzles
  - button to select puzzle

Future
- password-protected rooms


