### PR TITLE
sanitize puzzles for pg unsupported unicode sequence

### DIFF
--- a/server/sql/adhoc/sanitize_puzzles_1_24_21.sql
+++ b/server/sql/adhoc/sanitize_puzzles_1_24_21.sql
@@ -1,0 +1,23 @@
+-- invocation: copy/paste this into psql:
+UPDATE PUBLIC.PUZZLES
+SET content = regexp_replace(content::text, '\\u0000', '', 'g')::json;
+
+-- SELECT regexp_replace(content::text, '\\u0000', '', 'g'))::json from puzzles limit 50
+
+
+-- TESTING:
+-- test against the query from model/puzzle.ts that was failing:
+
+-- **error**:
+-- "unsupported Unicode escape sequence"
+
+-- **query for reproduction**:
+-- SELECT pid, uploaded_at, content, 
+-- regexp_replace(content::text, '\\u0000', '', 'g')::json as rg
+-- FROM puzzles
+-- WHERE is_public = true
+-- AND (content->'info'->>'type') = ANY('{Mini Puzzle, Daily Puzzle}')
+-- AND ((content -> 'info' ->> 'title') || (content->'info'->>'author')) ILIKE ALL('{%%}')
+-- ORDER BY pid DESC 
+-- LIMIT 50
+-- OFFSET 0;


### PR DESCRIPTION
this was causing issues when filtering on puzzle json content.
this is a follow-up to https://github.com/downforacross/downforacross.com/pull/149