### PR TITLE
migrate column content to jsonb

### DIFF
--- a/server/sql/adhoc/migrate_puzzles_content_1_24_21.sql
+++ b/server/sql/adhoc/migrate_puzzles_content_1_24_21.sql
@@ -1,0 +1,6 @@
+-- see https://github.com/downforacross/downforacross.com/pull/148#discussion_r563510048
+-- **invocation**: psql < migrate_puzzles_content_1_24_21.sql
+ALTER TABLE PUBLIC.PUZZLES
+  ALTER COLUMN content
+  SET DATA TYPE jsonb
+  USING content::jsonb;


### PR DESCRIPTION
a follow-up to https://github.com/downforacross/downforacross.com/pull/148

- [x] ran with `psql < migrate_puzzles_content_1_24_21.sql`
- [x] ran with `PGDATABASE=production psql < migrate_puzzles_content_1_24_21.sql`

```
psql -c '\d puzzles' 
                           Table "public.puzzles"
   Column    |            Type             | Collation | Nullable | Default 
-------------+-----------------------------+-----------+----------+---------
 uid         | text                        |           |          | 
 pid         | text                        |           | not null | 
 is_public   | boolean                     |           |          | 
 uploaded_at | timestamp without time zone |           |          | 
 content     | jsonb                       |           |          | 
Indexes:
    "puzzles_pkey" PRIMARY KEY, btree (pid)

PGDATABASE=production psql -c '\d puzzles'
                           Table "public.puzzles"
   Column    |            Type             | Collation | Nullable | Default 
-------------+-----------------------------+-----------+----------+---------
 uid         | text                        |           |          | 
 pid         | text                        |           | not null | 
 is_public   | boolean                     |           |          | 
 uploaded_at | timestamp without time zone |           |          | 
 content     | jsonb                       |           |          | 
Indexes:
    "puzzles_pkey" PRIMARY KEY, btree (pid)
```