### PR TITLE
Fix search

### DIFF
--- a/src/components/PuzzleList/NewPuzzleList.tsx
+++ b/src/components/PuzzleList/NewPuzzleList.tsx
@@ -59,7 +59,7 @@ const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
       500,
       {trailing: true}
     ),
-    [loading]
+    [loading, JSON.stringify(props.filter)]
   );
   useEffect(() => {
     // it is debatable if we want to blank out the current puzzles here or not,

--- a/src/components/PuzzleList/NewPuzzleList.tsx
+++ b/src/components/PuzzleList/NewPuzzleList.tsx
@@ -102,7 +102,6 @@ const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
       }[data.entryProps.status];
       return props.statusFilter[mappedStatus];
     });
-  console.log('Render new puzzle list', puzzles);
   return (
     <div
       ref={containerRef}


### PR DESCRIPTION
The new puzzle list search was always lagging behind by one character type which was not ideal.

This is fixed by making the react callback actually depend on the filters which will make the search match all of the current filters, because we will reload whenever the filter changes.

We JSON stringify as react compares with === so if we do not then it will change on every render rather than only then the filters actually change.