### PR TITLE
Show better feedback when a user uploads an invalid .puz file

### DIFF
--- a/src/components/Upload/FileUploader.js
+++ b/src/components/Upload/FileUploader.js
@@ -6,6 +6,7 @@ import {MdFileUpload} from 'react-icons/md';
 
 import {hasShape} from '../../lib/jsUtils';
 import PUZtoJSON from '../../lib/converter/PUZtoJSON';
+import swal from 'sweetalert';
 
 export default class FileUploader extends Component {
   validPuzzle(puzzle) {
@@ -56,11 +57,21 @@ export default class FileUploader extends Component {
     const reader = new FileReader();
     const {success, fail} = this.props;
     reader.addEventListener('loadend', () => {
-      const puzzle = this.convertPUZ(reader.result);
-      if (this.validPuzzle(puzzle)) {
-        success(puzzle);
-      } else {
-        fail();
+      try {
+        const puzzle = this.convertPUZ(reader.result);
+        if (this.validPuzzle(puzzle)) {
+          success(puzzle);
+        } else {
+          fail();
+        }
+      } catch (e) {
+        swal({
+          title: `Invalid .puz file`,
+          text: `The uploaded file is not a valid .puz file.`,
+          icon: 'warning',
+          buttons: 'OK',
+          dangerMode: true,
+        });
       }
       window.URL.revokeObjectURL(acceptedFiles[0].preview);
     });

--- a/src/components/Upload/Upload.js
+++ b/src/components/Upload/Upload.js
@@ -4,6 +4,7 @@ import React, {Component} from 'react';
 import actions from '../../actions';
 import FileUploader from './FileUploader';
 import {createNewPuzzle} from '../../api/puzzle';
+import swal from 'sweetalert';
 
 export default class Upload extends Component {
   constructor() {
@@ -43,7 +44,15 @@ export default class Upload extends Component {
     });
   };
 
-  fail = () => {};
+  fail = () => {
+    swal({
+      title: `Malformed .puz file`,
+      text: `The uploaded .puz file is not a valid puzzle.`,
+      icon: 'warning',
+      buttons: 'OK',
+      dangerMode: true,
+    });
+  };
 
   renderSuccessMessage() {
     const {info} = this.state.puzzle || {};


### PR DESCRIPTION
Currently, upon uploading an invalid .puz file, the upload silently fails with the unhandled exception or error showing up in the console as seen below.
- ![image](https://user-images.githubusercontent.com/6465531/109259729-d379b500-77ca-11eb-99bc-8003566ad33a.png)
- ![image](https://user-images.githubusercontent.com/6465531/109263209-e1323900-77d0-11eb-9aa2-49e485d314ff.png)

The modals from these changes should add better feedback for the following 2 cases.

**1. When the file _is not_ in valid .puz format, this modal is shown.**
![image](https://user-images.githubusercontent.com/6465531/109259671-afb66f00-77ca-11eb-9a95-0209703cbcef.png)

**2. When the file _is_ in valid .puz format, but the parsed puzzle is not a valid puzzle, this modal is shown.**
![image](https://user-images.githubusercontent.com/6465531/109259590-83025780-77ca-11eb-9397-4a7cb634d2b2.png)