### PR TITLE
Fix blurry modals by overriding will-change property

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -41,3 +41,7 @@ button {
   --main-green-1: rgba(31, 255, 61, 0.3);
   --main-green-2: rgba(31, 255, 61, 1);
 }
+
+.swal-modal {
+  will-change: unset !important;
+}


### PR DESCRIPTION
As of Chrome 53, the `will-change` CSS property will cause objects to not re-rasterize after a `transform` is applied. This causes the side effect of blurry images and texts. Read more about the issue here:
- https://googlechrome.github.io/samples/css-will-change-transform-rasterization/
- https://greensock.com/will-change/
- https://stackoverflow.com/a/54082690

The SweetAlert library uses the `will-change` property to optimize their animations, but this causes an undesirable side-effect as the text, buttons, and edges of modals appear to be blurry. This change overrides the default CSS of SweetAlert to fix this. Take note of the subtle differences below (on Chrome 88.0.4324.190).

Before:
![image](https://user-images.githubusercontent.com/6465531/109367194-66662e00-7863-11eb-84d7-6b4648b88efd.png)

After:
![image](https://user-images.githubusercontent.com/6465531/109367245-944b7280-7863-11eb-8d95-5cb7987bfba0.png)


