### PR TITLE
Add Shift-Arrow keyboard navigation for perpendicular cursor movement

### DIFF
--- a/src/components/Player/GridControls.js
+++ b/src/components/Player/GridControls.js
@@ -132,6 +132,12 @@ export default class GridControls extends Component {
       ']': 'forward',
     };
 
+    if (shiftKey) {
+      const isAcross = this.props.direction === 'across'
+      actionKeys[isAcross ? 'ArrowUp' : 'ArrowLeft'] = 'backward'
+      actionKeys[isAcross ? 'ArrowDown' : 'ArrowRight'] = 'forward'
+    }
+
     const {onPressEnter, onPressPeriod, onPressEscape} = this.props;
     if (key in actionKeys) {
       this.handleAction(actionKeys[key], shiftKey);

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -208,7 +208,14 @@ export default class Toolbar extends Component {
                   <code>[</code>
                   {' '}
                   and
+                  {' '}
                   <code>]</code>
+                  {' '}
+                  OR
+                  {' '} 
+                  <code>Shift</code>
+                  {' '}
+                  with arrow keys
                 </td>
                 <td>Move cursor perpendicular to current orientation without changing orientation</td>
               </tr>


### PR DESCRIPTION
This PR makes it possible to move cursor perpendicular to current orientation without changing orientation, using the same keyboard shortcuts as Across Lite (Shift-Arrow). Requested in #164 