### PR TITLE
Add info modal with links to Discord and GitHub

### DIFF
--- a/src/components/common/Nav.js
+++ b/src/components/common/Nav.js
@@ -1,9 +1,11 @@
 import './css/nav.css';
 
 import {Link} from 'react-router-dom';
+import ReactDOMServer from 'react-dom/server';
 import React, {useContext} from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import classnames from 'classnames';
+import swal from "sweetalert";
 import GlobalContext from '../../lib/GlobalContext';
 import {getUser} from '../../store/user';
 
@@ -43,6 +45,42 @@ function LogIn({user, style}) {
   );
 }
 
+function getInfoHTML() {
+  const infoReactElement = (
+    <div className="swal-text swal-text--no-margin">
+      <p>
+        Down for a Cross is an online website for sharing crosswords and playing collaboratively with friends in real time. Join the&nbsp;
+        <a href="https://discord.gg/KjPHFw8" target="_blank" rel="noreferrer">community Discord</a>
+        &nbsp;for more discussion.
+      </p>
+      <hr className="info--hr" />
+      <p>
+        Down for a Cross is open to contributions from developers of any level or experience. For more information or to report any issues, check out the project on&nbsp;
+        <a href="https://github.com/downforacross/downforacross.com" target="_blank" rel="noreferrer">GitHub</a>
+        .
+      </p>
+    </div>
+  );
+  const infoHtmlString = ReactDOMServer.renderToStaticMarkup(infoReactElement);
+  return infoHtmlString;
+}
+
+function htmlToElement(html) {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  return template.content.firstChild;
+}
+
+function showInfo() {
+  const infoHTML = getInfoHTML();
+  const infoContent = htmlToElement(infoHTML);
+  swal({
+    title: "downforacross.com",
+    content: infoContent,
+    icon: "info"
+  });
+}
+
 export default function Nav({hidden, v2, canLogin, mobile, linkStyle, divRef}) {
   const {toggleMolesterMoons} = useContext(GlobalContext);
   if (hidden) return null; // no nav for mobile
@@ -52,14 +90,17 @@ export default function Nav({hidden, v2, canLogin, mobile, linkStyle, divRef}) {
       <div className="nav--left" style={linkStyle}>
         <Link to={v2 ? '/beta' : '/'}>Down for a Cross</Link>
       </div>
-      <div className="molester-moon" onClick={toggleMolesterMoons}>
-        Dark Mode (beta)
-      </div>
-      {canLogin && (
-        <div className="nav--right">
-          <LogIn user={user} />
+      <div className="nav--right">
+        <div className="molester-moon" onClick={toggleMolesterMoons}>
+          Dark Mode (beta)
         </div>
-      )}
+        <div className="nav--info" onClick={showInfo}>
+          <i className="fa fa-info-circle" />
+        </div>
+        {canLogin && (
+          <LogIn user={user} />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/common/css/nav.css
+++ b/src/components/common/css/nav.css
@@ -15,6 +15,8 @@
 .nav--left {
   font-size: 17px;
   font-weight: bold;
+  display: flex;
+  align-items: center;
 }
 
 .nav.mobile .nav--left {
@@ -23,10 +25,11 @@
 
 .nav--right {
   margin-right: 10px;
-  align-self: flex-end;
   color: white;
   text-decoration: none;
   font-size: 13px;
+  display: flex;
+  align-items: center;
 }
 
 .nav.mobile .nav--right {
@@ -35,13 +38,18 @@
 
 .nav--login {
   cursor: pointer;
+  margin-left: 20px;
 }
 
 .nav--left a {
   color: white;
   text-decoration: none;
-  vertical-align: middle;
   font-size: 17px;
+}
+
+.nav--info {
+  cursor: pointer;
+  margin-left: 20px;
 }
 
 .nav--v2 {
@@ -57,4 +65,15 @@
 .secret:hover {
   opacity: 1;
   transition: all ease-in 2s;
+}
+
+.swal-text.swal-text--no-margin {
+  margin: 0 !important;
+}
+
+.info--hr {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  border: 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
Added an information 'i' icon to the nav bar.
![image](https://user-images.githubusercontent.com/6465531/109409589-03a78c00-7962-11eb-9cdc-039f4d883e51.png)

Clicking on the icon will pop up a modal with information about the site, including a link to the Discord and this GitHub.
![image](https://user-images.githubusercontent.com/6465531/109409598-1b7f1000-7962-11eb-9b9a-45138cf79263.png)

Tested on desktop and on mobile, and this change also inadvertently fixes the search bar flex-grow/shrink that wasn't working on mobile. The 'secret' button remains to the left of the info button. The 'Log In' button, if visible, is to the right of the info button.
