### PR TITLE
Added modals for uploading puzzles

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.9.14",
+    "@sweetalert/with-react": "^0.1.1",
     "@types/jest": "^25.2.1",
     "@types/lodash": "^4.14.150",
     "@types/morgan": "^1.9.2",

--- a/src/actions.js
+++ b/src/actions.js
@@ -37,7 +37,7 @@ const actions = {
     setPuzzle(pid, puzzle);
   },
   // puzzle: { title, type, grid, clues }
-  createPuzzle: (puzzle, cbk) => {
+  createPuzzle: async (puzzle, cbk) => {
     db.ref('counters').transaction(
       (counters) => {
         const pid = ((counters && counters.pid) || 0) + 1;

--- a/src/actions.js
+++ b/src/actions.js
@@ -37,7 +37,7 @@ const actions = {
     setPuzzle(pid, puzzle);
   },
   // puzzle: { title, type, grid, clues }
-  createPuzzle: async (puzzle, cbk) => {
+  createPuzzle: (puzzle, cbk) => {
     db.ref('counters').transaction(
       (counters) => {
         const pid = ((counters && counters.pid) || 0) + 1;

--- a/src/components/PuzzleList/NewPuzzleList.tsx
+++ b/src/components/PuzzleList/NewPuzzleList.tsx
@@ -16,6 +16,7 @@ interface NewPuzzleListProps {
     New: boolean;
   };
   puzzleStatuses: PuzzleStatuses;
+  uploadedPuzzles: number;
 }
 
 const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
@@ -65,7 +66,7 @@ const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
     // it is debatable if we want to blank out the current puzzles here or not,
     // for now we only change the puzzles when the reload happens.
     fetchMore([], 0);
-  }, [JSON.stringify(props.filter)]);
+  }, [JSON.stringify(props.filter), props.uploadedPuzzles]);
 
   const handleScroll = async () => {
     if (fullyLoaded) return;

--- a/src/components/PuzzleList/PuzzleList.js
+++ b/src/components/PuzzleList/PuzzleList.js
@@ -140,6 +140,7 @@ export default class PuzzleList extends PureComponent {
         filter={filter}
         statusFilter={this.props.statusFilter}
         puzzleStatuses={this.puzzleStatuses}
+        uploadedPuzzles={this.props.uploadedPuzzles}
       />
     );
   }

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -4,7 +4,7 @@ import {MdChatBubble} from 'react-icons/md';
 
 import Flex from 'react-flexview';
 import {Link} from 'react-router-dom';
-import swal from 'sweetalert';
+import swal from '@sweetalert/with-react';
 import Clock from './Clock';
 import ActionMenu from './ActionMenu';
 import Popup from './Popup';
@@ -165,11 +165,7 @@ export default class Toolbar extends Component {
             </li>
             <li>Click the clues to move the cursor directly to the cell for that answer</li>
             <li>
-              Hold down the 
-              {' '}
-              <code>Shift</code>
-              {' '}
-              key to enter multiple characters for rebus answers
+              Hold down the <code>Shift</code> key to enter multiple characters for rebus answers
             </li>
           </ul>
           <h4>Keyboard Shortcuts</h4>
@@ -187,9 +183,7 @@ export default class Toolbar extends Component {
               </tr>
               <tr>
                 <td>
-                  <code>.</code>
-                  {' '}
-                  (period)
+                  <code>.</code> (period)
                 </td>
                 <td>Toggle pencil mode on/off</td>
               </tr>
@@ -205,34 +199,22 @@ export default class Toolbar extends Component {
               </tr>
               <tr>
                 <td>
-                  <code>[</code>
-                  {' '}
-                  and
-                  {' '}
-                  <code>]</code>
-                  {' '}
-                  OR
-                  {' '} 
-                  <code>Shift</code>
-                  {' '}
-                  with arrow keys
+                  <code>[</code> and
+                  <code>]</code> OR
+                  <code>Shift</code> with arrow keys
                 </td>
                 <td>Move cursor perpendicular to current orientation without changing orientation</td>
               </tr>
               <tr>
                 <td>
-                  <code>Tab</code>
-                  {' '}
-                  and
+                  <code>Tab</code> and
                   <code>Shift+Tab</code>
                 </td>
                 <td>Move cursor to first unfilled square of next or previous unfilled clue</td>
               </tr>
               <tr>
                 <td>
-                  <code>Delete</code>
-                  {' '}
-                  or
+                  <code>Delete</code> or
                   <code>Backspace</code>
                 </td>
                 <td>Clear current cell</td>
@@ -282,8 +264,7 @@ export default class Toolbar extends Component {
       return (
         <Flex className="toolbar--mobile" vAlignContent="center">
           <Flex className="toolbar--mobile--top" grow={1} vAlignContent="center">
-            <Link to="/">DFAC</Link>
-            {' '}
+            <Link to="/">DFAC</Link>{' '}
             <Clock
               v2={this.props.v2}
               startTime={startTime}

--- a/src/components/Upload/FileUploader.js
+++ b/src/components/Upload/FileUploader.js
@@ -3,10 +3,10 @@ import './css/fileUploader.css';
 import React, {Component} from 'react';
 import Dropzone from 'react-dropzone';
 import {MdFileUpload} from 'react-icons/md';
+import swal from '@sweetalert/with-react';
 
 import {hasShape} from '../../lib/jsUtils';
 import PUZtoJSON from '../../lib/converter/PUZtoJSON';
-import swal from 'sweetalert';
 
 export default class FileUploader extends Component {
   validPuzzle(puzzle) {
@@ -85,7 +85,7 @@ export default class FileUploader extends Component {
         className="file-uploader"
         onDrop={this.onDrop.bind(this)}
         activeStyle={{
-          outline: '3px solid black',
+          outline: '3px solid var(--main-blue)',
           outlineOffset: '-10px',
         }}
       >

--- a/src/components/Upload/Upload.js
+++ b/src/components/Upload/Upload.js
@@ -32,7 +32,7 @@ export default class Upload extends Component {
       private: !isPublic,
     };
     // store in both firebase & pg
-    await actions.createPuzzle(puzzle, (pid) => {
+    actions.createPuzzle(puzzle, (pid) => {
       this.setState({puzzle: null});
       this.setState({
         recentUnlistedPid: isPublic ? undefined : pid,

--- a/src/components/Upload/css/fileUploader.css
+++ b/src/components/Upload/css/fileUploader.css
@@ -3,6 +3,9 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  outline: 3px solid rgba(0,0,0,0);
+  outline-offset: -5px;
+  transition: outline-color 0.10s ease-in-out, outline-offset 0.10s ease-in-out;
 }
 
 .file-uploader--wrapper {

--- a/src/components/common/Nav.js
+++ b/src/components/common/Nav.js
@@ -5,7 +5,7 @@ import ReactDOMServer from 'react-dom/server';
 import React, {useContext} from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import classnames from 'classnames';
-import swal from "sweetalert";
+import swal from '@sweetalert/with-react';
 import GlobalContext from '../../lib/GlobalContext';
 import {getUser} from '../../store/user';
 
@@ -45,39 +45,31 @@ function LogIn({user, style}) {
   );
 }
 
-function getInfoHTML() {
-  const infoReactElement = (
-    <div className="swal-text swal-text--no-margin">
-      <p>
-        Down for a Cross is an online website for sharing crosswords and playing collaboratively with friends in real time. Join the&nbsp;
-        <a href="https://discord.gg/KjPHFw8" target="_blank" rel="noreferrer">community Discord</a>
-        &nbsp;for more discussion.
-      </p>
-      <hr className="info--hr" />
-      <p>
-        Down for a Cross is open to contributions from developers of any level or experience. For more information or to report any issues, check out the project on&nbsp;
-        <a href="https://github.com/downforacross/downforacross.com" target="_blank" rel="noreferrer">GitHub</a>
-        .
-      </p>
-    </div>
-  );
-  const infoHtmlString = ReactDOMServer.renderToStaticMarkup(infoReactElement);
-  return infoHtmlString;
-}
-
-function htmlToElement(html) {
-  const template = document.createElement('template');
-  template.innerHTML = html;
-  return template.content.firstChild;
-}
-
 function showInfo() {
-  const infoHTML = getInfoHTML();
-  const infoContent = htmlToElement(infoHTML);
   swal({
-    title: "downforacross.com",
-    content: infoContent,
-    icon: "info"
+    title: 'downforacross.com',
+    icon: 'info',
+    content: (
+      <div className="swal-text swal-text--no-margin">
+        <p>
+          Down for a Cross is an online website for sharing crosswords and playing collaboratively with
+          friends in real time. Join the&nbsp;
+          <a href="https://discord.gg/KjPHFw8" target="_blank" rel="noreferrer">
+            community Discord
+          </a>
+          &nbsp;for more discussion.
+        </p>
+        <hr className="info--hr" />
+        <p>
+          Down for a Cross is open to contributions from developers of any level or experience. For more
+          information or to report any issues, check out the project on&nbsp;
+          <a href="https://github.com/downforacross/downforacross.com" target="_blank" rel="noreferrer">
+            GitHub
+          </a>
+          .
+        </p>
+      </div>
+    ),
   });
 }
 
@@ -97,9 +89,7 @@ export default function Nav({hidden, v2, canLogin, mobile, linkStyle, divRef}) {
         <div className="nav--info" onClick={showInfo}>
           <i className="fa fa-info-circle" />
         </div>
-        {canLogin && (
-          <LogIn user={user} />
-        )}
+        {canLogin && <LogIn user={user} />}
       </div>
     </div>
   );

--- a/src/components/common/css/nav.css
+++ b/src/components/common/css/nav.css
@@ -67,10 +67,6 @@
   transition: all ease-in 2s;
 }
 
-.swal-text.swal-text--no-margin {
-  margin: 0 !important;
-}
-
 .info--hr {
   margin-top: 1rem;
   margin-bottom: 1rem;

--- a/src/pages/Welcome.js
+++ b/src/pages/Welcome.js
@@ -38,6 +38,7 @@ export default class Welcome extends Component {
     this.mobile = isMobile();
     this.searchInput = React.createRef();
     this.nav = React.createRef();
+    this.uploadedPuzzles = 0;
   }
 
   componentDidMount() {
@@ -145,6 +146,7 @@ export default class Welcome extends Component {
     return (
       <PuzzleList
         puzzles={puzzles}
+        uploadedPuzzles={this.uploadedPuzzles}
         userHistory={userHistory}
         sizeFilter={sizeFilter}
         statusFilter={statusFilter}
@@ -157,6 +159,7 @@ export default class Welcome extends Component {
 
   handleCreatePuzzle = () => {
     this.nextPage();
+    this.uploadedPuzzles += 1;
   };
 
   handleFilterChange = (header, name, on) => {

--- a/src/pages/css/welcome.css
+++ b/src/pages/css/welcome.css
@@ -33,9 +33,8 @@
 }
 
 .welcome--sidebar {
-  padding-bottom: 20px;
+  padding-bottom: 40px;
   border-right: 2px solid var(--main-blue);
-  overflow: auto;
 }
 
 .welcome--sidebar > div {

--- a/src/style.css
+++ b/src/style.css
@@ -45,3 +45,19 @@ button {
 .swal-modal {
   will-change: unset !important;
 }
+
+.swal-text--no-margin {
+  margin: 0 !important;
+}
+
+.swal-text--text-align-center {
+  text-align: center !important;
+}
+
+#unlistedRow {
+  margin-top: 10px;
+}
+
+#unlistedRow input {
+  display: inline-block;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1962,6 +1962,18 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
+"@sweetalert/transformer@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@sweetalert/transformer/-/transformer-0.1.1.tgz#638bdd20b862f03579fd906578dc9355db00887a"
+  integrity sha512-QdV8CrelIoK95kWOrZNMKXL9oEQFsvaForZcw2UijhmVJX/wzopPRLT/sAg51436TJ4q5angt8BvHQInehGFHA==
+
+"@sweetalert/with-react@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@sweetalert/with-react/-/with-react-0.1.1.tgz#5fe4ca967ae8fb34868ef0b9e52013b783e665d5"
+  integrity sha512-LC9eMYKsv8ydvhvKufdVPOIMDgbAFsxn7eeKWadwvXPsFcflosfm/cXZSO0Ras5TuaO3WxHEgvitKD6UfpeIwQ==
+  dependencies:
+    "@sweetalert/transformer" "^0.1.1"
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"


### PR DESCRIPTION
Uploading a puzzle should appropriately show the right modals on successful validation, where you can choose unlisted or public. Also refreshes the puzzles list upon confirming a public upload. Also some prettier CSS with the drag and drop.

After selecting a file to upload:
![image](https://user-images.githubusercontent.com/6465531/109895147-b6c2fe80-7c5c-11eb-8aaf-2ba6478786ba.png)

After selecting the upload button:
![image](https://user-images.githubusercontent.com/6465531/109894355-51bad900-7c5b-11eb-8d99-c11ae12e04b9.png)

After choosing unlisted and selecting the upload button:
![image](https://user-images.githubusercontent.com/6465531/109895059-94c97c00-7c5c-11eb-9584-49b1f95f453f.png)

By using the [@sweetalert/with-react](https://www.npmjs.com/package/@sweetalert/with-react) package, I was also able to remove some helper functions from the modals and allow for more extensibility and customization to the modals.

