### PR TITLE
Fix: Can't toggle selected direction on tablet

### DIFF
--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -59,6 +59,8 @@ interface Props {
  * - Grid
  * */
 export default class Cell extends React.Component<Props> {
+  private touchStart: {pageX: number; pageY: number} = {pageX: 0, pageY: 0};
+
   shouldComponentUpdate(nextProps: Props) {
     const pathsToOmit = ['cursors', 'pings', 'cellStyle'] as const;
     if (!_.isEqual(_.omit(nextProps, ...pathsToOmit), _.omit(this.props, pathsToOmit))) {
@@ -260,6 +262,21 @@ export default class Cell extends React.Component<Props> {
           style={style}
           onClick={this.handleClick}
           onContextMenu={this.handleRightClick}
+          onTouchStart={(e) => {
+            const touch = e.touches[e.touches.length - 1];
+            this.touchStart = {pageX: touch.pageX, pageY: touch.pageY};
+          }}
+          onTouchEnd={(e) => {
+            if (e.changedTouches.length !== 1 || e.touches.length !== 0) return;
+            const touch = e.changedTouches[0];
+            if (
+              !this.touchStart ||
+              (Math.abs(touch.pageX - this.touchStart.pageX) < 5 &&
+                Math.abs(touch.pageY - this.touchStart.pageY) < 5)
+            ) {
+              onClick(this.props.r, this.props.c);
+            }
+          }}
         >
           <div className="cell--wrapper">
             <div

--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -274,6 +274,7 @@ export default class Cell extends React.Component<Props> {
               (Math.abs(touch.pageX - this.touchStart.pageX) < 5 &&
                 Math.abs(touch.pageY - this.touchStart.pageY) < 5)
             ) {
+              e.preventDefault();
               onClick(this.props.r, this.props.c);
             }
           }}

--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -59,8 +59,6 @@ interface Props {
  * - Grid
  * */
 export default class Cell extends React.Component<Props> {
-  private touchStart: {pageX: number; pageY: number} = {pageX: 0, pageY: 0};
-
   shouldComponentUpdate(nextProps: Props) {
     const pathsToOmit = ['cursors', 'pings', 'cellStyle'] as const;
     if (!_.isEqual(_.omit(nextProps, ...pathsToOmit), _.omit(this.props, pathsToOmit))) {
@@ -262,21 +260,6 @@ export default class Cell extends React.Component<Props> {
           style={style}
           onClick={this.handleClick}
           onContextMenu={this.handleRightClick}
-          onTouchStart={(e) => {
-            const touch = e.touches[e.touches.length - 1];
-            this.touchStart = {pageX: touch.pageX, pageY: touch.pageY};
-          }}
-          onTouchEnd={(e) => {
-            if (e.changedTouches.length !== 1 || e.touches.length !== 0) return;
-            const touch = e.changedTouches[0];
-            if (
-              !this.touchStart ||
-              (Math.abs(touch.pageX - this.touchStart.pageX) < 5 &&
-                Math.abs(touch.pageY - this.touchStart.pageY) < 5)
-            ) {
-              onClick(this.props.r, this.props.c);
-            }
-          }}
         >
           <div className="cell--wrapper">
             <div


### PR DESCRIPTION
Fixes #181

After a simple touch event, modern mobile browsers fire a simulated "click" event.  I believe what's happening in this issue is that _both_ the `click` _and_ `touchend` event handlers are calling `onClick` for each tap on the screen.  This causes the state to flip from row to column mode and back.

There are more than one approach to fixing this issue:

1. At smaller screen sizes, when this app's extra "mobile" features kick in, this issue is no longer present. Activate that mode earlier, or port whatever logic changed between modes back to the tablet.
2. In  the `touchend` event handler, just before calling `onClick`,  call e.preventDefault().  This prevents the touch event from generating a simulated click event.

However, it strikes me that the "click" event generated by browsers is exactly what these touch handlers are attempting to emulate.  Unless I'm missing some context, they appear to be redundant.

This diff just removes the touch handlers from `Cell.tsx`.  I tested that this fixes the perceived issue on iPad.  I also tested on a Samsung S9 to confirm that touch events can still toggle column/row and there were no regressions to gesture-based pan and zoom.