### PR TITLE
Fix incorrect circle markups in some puzzles

### DIFF
--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -74,7 +74,7 @@ export default class Grid extends React.PureComponent<GridProps> {
 
   isCircled(r: number, c: number) {
     const {grid, circles} = this.props;
-    const idx = toCellIndex(r, c, grid.length);
+    const idx = toCellIndex(r, c, grid[0].length);
     return (circles || []).indexOf(idx) !== -1;
   }
 


### PR DESCRIPTION
toCellIndex requires number of columns, but the number of rows was being passed in, leading to the circles being the wrong place. Passing in grid[0].length fixes this. Addresses #122 and #183.