### PR TITLE
iPad OS no longer reports platform as iPad, by default

### DIFF
--- a/src/lib/jsUtils.js
+++ b/src/lib/jsUtils.js
@@ -48,7 +48,7 @@ export function colorAverage(hex1, hex2, weight) {
 if (typeof window !== 'undefined') {
   window.requestIdleCallback =
     window.requestIdleCallback ||
-    function(cb) {
+    function (cb) {
       const start = Date.now();
       return setTimeout(() => {
         cb({
@@ -62,7 +62,7 @@ if (typeof window !== 'undefined') {
 
   window.cancelIdleCallback =
     window.cancelIdleCallback ||
-    function(id) {
+    function (id) {
       clearTimeout(id);
     };
 }
@@ -128,6 +128,13 @@ function isMobile() {
       /Mobile|Windows Phone|Lumia|Android|webOS|iPhone|iPod|Blackberry|PlayBook|BB10|Opera Mini|\bCrMo\/|Opera Mobi/i
     )
   ) {
+    // do mobile stuff
+    return true;
+  }
+  // iPadOS mimics desktop clients by default, but can be detected by the
+  // presence of touch support.
+  // https://stackoverflow.com/a/64559209
+  if (navigator.platform.match(/MacIntel/) && navigator.maxTouchPoints > 0) {
     // do mobile stuff
     return true;
   }


### PR DESCRIPTION
Hello again!

Since my previous pull request, I realised that part of why my experience on iPad has been so degraded is that the "desktop" version of downforacross was never intended to support devices without a hardware keyboard.

With the introduction of iPadOS, it seems iPads stopped reporting themselves as iPads (by default).  Instead, they report themselves identically to mac devices, unless a "request desktop site" option is disabled.

With that knowledge, as a user, I discovered that I can toggle that setting and get access to the mobile version of downforacross.  👍 

I decided to push this pull request, but I'm not certain it's a good idea.

This pull request updates the mobile detection logic to more reliably identify iPadOS by looking at the presence of touchscreen support in combination with a "MacIntel" platform.  It's definitely debatable whether the value outweighs associated risks (for example, if Apple ever does release a touchscreen laptop, or if a user is using an iPad with physical keyboard and does want the desktop site).

If other users run into this issue, another idea that might be worth considering is adding a button (or link) at the bottom of the page that allows users to opt into the mobile controls.  Anyway, I'm pushing this option, but I leave it up to you to decide what, if anything, is worth pursuing!