### PR TITLE
Add keyboard shortcuts for check/reveal

### DIFF
--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -274,6 +274,8 @@ export default class Game extends Component {
         mobile={mobile}
         pickups={this.props.pickups}
         optimisticCounter={optimisticCounter}
+        onCheck={this.handleCheck}
+        onReveal={this.handleReveal}
         {...themeStyles}
       />
     );

--- a/src/components/Player/GridControls.js
+++ b/src/components/Player/GridControls.js
@@ -121,6 +121,20 @@ export default class GridControls extends Component {
     actions[action](shiftKey);
   }
 
+  handleAltKey(key, shiftKey) {
+    key = key.toLowerCase();
+    const altAction = shiftKey ? this.props.onReveal : this.props.onCheck;
+    if (key === 's') {
+      altAction('square');
+    }
+    if (key === 'w') {
+      altAction('word');
+    }
+    if (key === 'p') {
+      altAction('puzzle');
+    }
+  }
+
   validLetter(letter) {
     const VALID_SYMBOLS = '!@#$%^&*()-+=`~/?\\'; // special theme puzzles have these sometimes;
     if (VALID_SYMBOLS.indexOf(letter) !== -1) return true;
@@ -163,17 +177,7 @@ export default class GridControls extends Component {
       return true;
     }
     if (altKey) {
-      key = key.toLowerCase();
-      const altAction = shiftKey ? this.props.onReveal : this.props.onCheck;
-      if (key === 's') {
-        altAction('square');
-      }
-      if (key === 'w') {
-        altAction('word');
-      }
-      if (key === 'p') {
-        altAction('puzzle');
-      }
+      this.handleAltKey(key, shiftKey);
       return true;
     }
     if (key === 'Escape') {
@@ -213,6 +217,10 @@ export default class GridControls extends Component {
     const {onVimNormal, onVimInsert, vimInsert, onPressEnter, onPressPeriod} = this.props;
     if (key in actionKeys) {
       this.handleAction(actionKeys[key], shiftKey);
+      return true;
+    }
+    if (altKey) {
+      this.handleAltKey(key, shiftKey);
       return true;
     }
     if (!vimInsert) {

--- a/src/components/Player/GridControls.js
+++ b/src/components/Player/GridControls.js
@@ -128,7 +128,7 @@ export default class GridControls extends Component {
   }
 
   // takes in key, a string
-  _handleKeyDown = (key, shiftKey) => {
+  _handleKeyDown = (key, shiftKey, altKey) => {
     const actionKeys = {
       ArrowLeft: 'left',
       ArrowUp: 'up',
@@ -162,6 +162,20 @@ export default class GridControls extends Component {
       onPressEnter && onPressEnter();
       return true;
     }
+    if (altKey) {
+      key = key.toLowerCase();
+      const altAction = shiftKey ? this.props.onReveal : this.props.onCheck;
+      if (key === 's') {
+        altAction('square');
+      }
+      if (key === 'w') {
+        altAction('word');
+      }
+      if (key === 'p') {
+        altAction('puzzle');
+      }
+      return true;
+    }
     if (key === 'Escape') {
       onPressEscape && onPressEscape();
     } else if (!this.props.frozen) {
@@ -173,7 +187,7 @@ export default class GridControls extends Component {
     }
   };
 
-  _handleKeyDownVim = (key, shiftKey) => {
+  _handleKeyDownVim = (key, shiftKey, altKey) => {
     const actionKeys = {
       ArrowLeft: 'left',
       ArrowUp: 'up',
@@ -239,7 +253,7 @@ export default class GridControls extends Component {
     if (ev.target.tagName === 'INPUT' || ev.metaKey || ev.ctrlKey) {
       return;
     }
-    if (_handleKeyDown(ev.key, ev.shiftKey)) {
+    if (_handleKeyDown(ev.key, ev.shiftKey, ev.altKey)) {
       ev.preventDefault();
       ev.stopPropagation();
     }

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -403,6 +403,8 @@ export default class Player extends Component {
           grid={grid}
           clues={clues}
           beta={beta}
+          onCheck={this.props.onCheck}
+          onReveal={this.props.onReveal}
         >
           <div className="player--main">
             <div className="player--main--left">

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -219,6 +219,22 @@ export default class Toolbar extends Component {
                 </td>
                 <td>Clear current cell</td>
               </tr>
+              <tr>
+                <td>
+                  <code>Alt</code> + <code>S</code>, <code>W</code>, or <code>P</code>
+                </td>
+                <td>
+                  Check <b>S</b>quare, <b>W</b>ord, or <b>P</b>uzzle
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>Alt</code> + <code>Shift</code> + <code>S</code>, <code>W</code>, or <code>P</code>
+                </td>
+                <td>
+                  Reveal <b>S</b>quare, <b>W</b>ord, or <b>P</b>uzzle
+                </td>
+              </tr>
             </tbody>
           </table>
         </Popup>


### PR DESCRIPTION
Adds keyboard shortcuts for check/reveal square, word, and puzzle. No confirmation dialog.

Alt + S, W, or P - Check square, word, or puzzle
Alt + Shift + S, W, or P - Reveal square, word, or puzzle

![image](https://user-images.githubusercontent.com/6465531/132066397-3ea2eb46-36f1-4815-93c4-ce4396a96af7.png)
