### PR TITLE
Update logic for setting initial selected squares

### DIFF
--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -42,12 +42,13 @@ const PING_TIMEOUT = 10000;
 export default class Player extends Component {
   constructor(props) {
     super(props);
+    const selected =
+      this.props.currentCursor?.r && this.props.currentCursor?.c
+        ? this.props.currentCursor
+        : this.getInitialSelected();
     this.state = {
-      selected: {
-        r: this.props.currentCursor?.r ?? 0,
-        c: this.props.currentCursor?.c ?? 0,
-      },
-      direction: 'across',
+      selected: selected,
+      direction: this.props.clues.across.length ? 'across' : 'down',
     };
 
     // for deferring scroll-to-clue actions
@@ -110,11 +111,30 @@ export default class Player extends Component {
   get selected() {
     let {r, c} = this.state.selected;
     while (!this.grid.isWhite(r, c)) {
-      if (c < this.props.grid[0].length) {
+      if (c + 1 < this.props.grid[0].length) {
         c += 1;
-      } else {
+      } else if (r + 1 < this.props.grid.length) {
         r += 1;
         c = 0;
+      } else {
+        return {r: 0, c: 0};
+      }
+    }
+    return {r, c};
+  }
+
+  getInitialSelected() {
+    let r = 0;
+    let c = 0;
+    let direction = this.props.clues.across.length ? 'across' : 'down';
+    while (!this.grid.isWhite(r, c) || !this.props.clues[direction][this.grid.getParent(r, c, direction)]) {
+      if (c + 1 < this.props.grid[0].length) {
+        c += 1;
+      } else if (r + 1 < this.props.grid.length) {
+        r += 1;
+        c = 0;
+      } else {
+        return {r: 0, c: 0};
       }
     }
     return {r, c};

--- a/src/lib/wrappers/GridWrapper.js
+++ b/src/lib/wrappers/GridWrapper.js
@@ -262,7 +262,7 @@ export default class GridWrapper {
   }
 
   getParent(r, c, direction) {
-    return this.grid[r][c].parents[direction];
+    return this.grid[r][c].parents?.[direction] ?? 0;
   }
 
   isStartOfClue(r, c, direction) {


### PR DESCRIPTION
Updates logic for setting the initially selected squares on puzzle load.

Selects first available 'across' clues, and then first available 'down' clues. Defaults to selecting {0,0} if none found. For example, if a puzzle does not have 1A, but has 4A (see https://downforacross.com/beta/game/1083156-trag), the 4A squares will be selected on page load.

Handles edge cases where puzzles:
-Don't have 1A clue
-Don't have any across clues
-Don't have any clues (though we should not allow such puzzles to be uploaded in the first place)

Should address #199 and #203.