### PR TITLE
Mobile Control Enhancement

### DIFF
--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -446,6 +446,8 @@ export default class MobileGridControls extends GridControls {
       // hack hack
       // for some reason, email input [on ios safari & chrome mobile inspector] doesn't fire onChange at all when pressing spacebar
       this.handleAction('space');
+    } else if (input === ',') {
+      this.handleAction('tab');
     } else if (input === '.') {
       this.props.onPressPeriod && this.props.onPressPeriod();
     } else {


### PR DESCRIPTION
Bound the comma key on a mobile keyboard to replicate the behavior of tab on web. Moving between clues is cumbersome without it (in my opinion of course 😄 ).

I'm completely unsure if this is the right way to go about suggesting a change like this so please let me know!