### PR TITLE
Decode HTML in Clues

### DIFF
--- a/src/components/Player/ClueText.js
+++ b/src/components/Player/ClueText.js
@@ -1,7 +1,14 @@
 import React from 'react';
 
+function decodeHtml(htmlText) {
+  let text = document.createElement("textarea");
+  text.innerHTML = htmlText;
+  return text.value;
+}
+
 export default ({text = ''}) => {
   const parts = [];
+
   while (text.length > 0) {
     const s = text.indexOf('<i>');
     const e = text.indexOf('</i>');
@@ -23,11 +30,12 @@ export default ({text = ''}) => {
       text = '';
     }
   }
+
   return (
     <>
       {parts.map(({text, ital}, i) => (
         <span key={i} style={{fontStyle: ital ? 'italic' : 'inherit'}}>
-          {text}
+          {decodeHtml(text)}
         </span>
       ))}
     </>

--- a/src/components/Player/ClueText.js
+++ b/src/components/Player/ClueText.js
@@ -8,7 +8,6 @@ function decodeHtml(htmlText) {
 
 export default ({text = ''}) => {
   const parts = [];
-
   while (text.length > 0) {
     const s = text.indexOf('<i>');
     const e = text.indexOf('</i>');
@@ -30,7 +29,6 @@ export default ({text = ''}) => {
       text = '';
     }
   }
-
   return (
     <>
       {parts.map(({text, ital}, i) => (


### PR DESCRIPTION
Partially addresses #220 . Decoding HTML encoded clue values. Very unsure if this is the _best_ way to fix this, but it does appear to work 😄 

The puzzle provided in #220 does have a few examples of this but it doesn't appear I can upload that puz file to the issue 😢 