### PR TITLE
Tweak margin around chat system messages

### DIFF
--- a/src/components/Chat/css/index.css
+++ b/src/components/Chat/css/index.css
@@ -106,7 +106,7 @@
 
 .chat--system-message {
   color: var(--main-gray-1);
-  margin-bottom: 10px;
+  margin: 5px;
 }
 
 .chat--message--timestamp {


### PR DESCRIPTION
Changed `margin-bottom: 10px;` to a `margin: 5px;` to add a little more space around system chat messages. I didn't like how close the message was to the horizontal bar below the player names. No one really asked for this, but I think it looks nicer 🤠 If there are more system messages to be added in the future, this will come in handy.

Before:
![image](https://user-images.githubusercontent.com/6465531/208828433-98d48eaf-1e79-48a2-befd-f0852a314639.png)

After:
![image](https://user-images.githubusercontent.com/6465531/208828392-1a46c72b-e5e5-48ee-8a27-2eca7975f918.png)