### PR TITLE
Remove border-right on toolbar

### DIFF
--- a/src/components/Toolbar/css/index.css
+++ b/src/components/Toolbar/css/index.css
@@ -8,7 +8,6 @@ code {
   min-height: 20px;
   border-top: 1px solid #e2e2e2;
   border-left: 1px solid #e2e2e2;
-  border-right: 1px solid #e2e2e2;
   border-bottom: 1px solid #e2e2e2;
 
   display: flex;


### PR DESCRIPTION
Fixes double border caused by the toolbar and chat.

Before:
![image](https://user-images.githubusercontent.com/6465531/208832948-9074f501-3894-4723-a9c3-268692ed58c0.png)

After:
![image](https://user-images.githubusercontent.com/6465531/208832987-228f4178-7a8c-41c8-a180-2ff74869154d.png)
