### PR TITLE
Make backend development more windows-friendly

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -1,1 +1,3 @@
 export PGDATABASE=dfac
+export PGUSER=postgres
+export PGPASSWORD=password

--- a/package.json
+++ b/package.json
@@ -91,9 +91,9 @@
   },
   "scripts": {
     "start": "cross-env PORT=3020 react-scripts start",
-    "devfrontend": "REACT_APP_USE_LOCAL_SERVER=1 PORT=3020 react-scripts start",
+    "devfrontend": "cross-env REACT_APP_USE_LOCAL_SERVER=1 PORT=3020 react-scripts start",
     "devfrontendprod": "REACT_APP_ENV=production REACT_APP_USE_LOCAL_SERVER=1 PORT=3020 react-scripts start",
-    "devbackend": "PORT=3021 nodemon --watch server -e \"ts\" --exec \"npx ts-node -P server/tsconfig.json server/server.ts\"",
+    "devbackend": "cross-env PORT=3021 nodemon --watch server -e \"ts\" --exec \"npx ts-node -P server/tsconfig.json server/server.ts\"",
     "devbackendprod": "source .env.prod; PORT=3021 nodemon --watch server -e \"ts\" --exec \"npx ts-node -P server/tsconfig.json server/server.ts\"",
     "servebackendprod": "while true; do env $(cat .env.prod | xargs) PORT=3021 ts-node -P server/tsconfig.json server/server.ts || true; done",
     "servebackendstaging": "while true; do env $(cat .env.staging | xargs) PORT=4021 ts-node -P server/tsconfig.json server/server.ts || true; done",

--- a/server/README.md
+++ b/server/README.md
@@ -81,7 +81,8 @@ psql dfac < create_game_events.sql
 
 `yarn devbackend`
 
-This command expects you to have PGDATABASE env var set and a postgres server running. See `.envrc.template`.
+This command expects you to have PGDATABASE, PGUSER, and PGPASSWORD env vars set and a postgres server running. See `.envrc.template`.  
+Copy and rename `.envrc.template` to `.envrc` to set these variables (make sure to have [DirEnv](https://direnv.net/) installed).  
 This will run a backend server on `localhost:3021`
 
 #### Run your local frontend server
@@ -89,8 +90,6 @@ This will run a backend server on `localhost:3021`
 `yarn devfrontend`
 
 This will run a frontend server on localhost:3020, that talks to your server on `localhost:3021`.
-
-Note that you can also run
 
 #### Test manually
 


### PR DESCRIPTION
Adding `cross-env` to the npm scripts sections for `devfrontend` and `devbackend`. I presume these will need to be added for the other scripts as well, but just adding these in for now.

Also making a note about DirEnv since it does not come pre-packaged with Windows, and added a few more env variables that might cause issues if not automatically set. For reference, the following error is returned if the PGUSER/PGPASSWORD is not set.

```
TypeError [ERR_INVALID_ARG_TYPE]: The "key" argument must be of type string or an instance of Buffer, TypedArray, DataView, or KeyObject. Received null
```