### PR TITLE
Change dark mode colors

### DIFF
--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -211,6 +211,7 @@ export default class Cell extends React.Component<Props> {
       onClick,
       number,
       referenced,
+      frozen,
     } = this.props;
     if (black || isHidden) {
       return (
@@ -249,6 +250,7 @@ export default class Cell extends React.Component<Props> {
             good,
             revealed,
             pencil,
+            frozen,
           })}
           style={style}
           onClick={this.handleClick}

--- a/src/components/common/css/nav.css
+++ b/src/components/common/css/nav.css
@@ -17,6 +17,7 @@
   font-weight: bold;
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .nav.mobile .nav--left {

--- a/src/dark.css
+++ b/src/dark.css
@@ -4,6 +4,9 @@
   font-family: courier;
   opacity: 0;
   cursor: pointer;
+  text-align: right;
+  margin-top: -10px; /* Ignore padding from parent so dark mode setting doesn't expand Nav bar */
+  margin-bottom: -10px; /* Can remove these if there's a more compact dark mode switching UI */
 }
 
 .molester-moon:hover {
@@ -12,22 +15,30 @@
 }
 
 .dark {
-  background-color: #111;
-  color: #bbb;
+  background-color: var(--background);
+  color: var(--primary-text);
 }
 
 .dark .nav {
-  background-color: var(--dark-blue) !important;
+  background-color: var(--dark-blue-1) !important;
 }
 
 /* Game Page */
 
 .dark .player--main--clue-bar {
-  background-color: var(--dark-blue) !important;
+  background-color: var(--dark-blue-2) !important;
+}
+
+.dark .mobile-grid-controls--clue-bar {
+  background-color: var(--dark-blue-2);
+}
+
+.dark .mobile-grid-controls--intra-clue {
+  background-color: var(--dark-blue-2);
 }
 
 .dark .player--main--left--grid {
-  color: #ccc;
+  color: var(--primary-text);
 }
 
 .dark .grid--cell {
@@ -35,31 +46,65 @@
 }
 
 .dark .cell {
-  background-color: #111;
+  background-color: var(--background-2);
+  color: var(--primary-text);
 }
 .dark .cell.black {
-  background-color: #333;
+  background-color: var(--background);
 }
 
 .dark .cell.highlighted {
-  background-color: rgb(22, 50, 114) !important;
+  background-color: var(--dark-blue-2) !important;
+}
+
+.dark .cell.referenced {
+  background-color: #80A030 !important;
+  color: white;
+}
+
+.dark .cell.frozen.highlighted {
+  background-color: #399629 !important;
+  color: white;
+}
+
+.dark .cell.referenced .cell--value{
+  color: white !important;
+}
+
+.dark .cell.pencil .cell--value {
+  color: rgba(255, 255, 255, 0.47);
+}
+
+.dark .clues--list--scroll {
+  background-color: var(--background-1);
 }
 
 .dark .clues--list--scroll--clue.selected {
-  background-color: var(--dark-blue) !important;
+  background-color: var(--dark-blue-2);
 }
 
 .dark .clues--list--scroll--clue.half-selected {
-  background-color: #333;
-  border-left-color: var(--dark-blue);
+  background-color: var(--background-1);
+  border-left-color: var(--dark-blue-2);
 }
 
 .dark .chat--header--title {
-  color: #ccc;
+  color: var(--primary-text);
+}
+
+.dark .chat--system-message {
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .dark .clues--list--scroll {
   border-top-color: #555;
+}
+.dark .clues--list--scroll--clue.complete {
+  color: rgba(255, 255, 255, 0.47);
+}
+
+.dark .list-view--list--title {
+  background-color: var(--background);
 }
 
 .dark ::-webkit-scrollbar-thumb {
@@ -67,8 +112,8 @@
 }
 
 .dark .toolbar button {
-  background-color: #111;
-  color: #ccc;
+  background-color: rgba(0, 0, 0, 0);
+  color: var(--primary-text);
 }
 
 .dark .toolbar {
@@ -76,10 +121,17 @@
   border-left: none;
   border-top: none;
   border-bottom-color: #888;
+  background-color: var(--background-2);
 }
+
+.dark .toolbar--mobile {
+  background-color: var(--dark-blue-1);
+}
+
 
 .dark .chat {
   border-color: #888;
+  background-color: var(--background-1);
 }
 
 .dark .chat--header {
@@ -91,23 +143,28 @@
   border-right: none !important;
   border-top: none !important;
 }
-.dark .cell.selected {
-  background-color: #086c3a !important;
+.dark .cell.selected .cell--wrapper{
+  background-color: rgba(0,0,0,0.1);
 }
 
 .dark .cell.good .cell--value {
-  color: #9f9fff;
+  color: #a3baff;
+}
+
+.dark .cell.bad .cell--value {
+  color: rgb(244, 67, 54);
 }
 
 .dark .cell.revealed .cell--value {
-  color: #44cc44;
+  color: rgb(102, 187, 106);
 }
 
 .dark input {
-  background-color: #111;
-  color: #ccc;
-  border-color: #ccc;
+  background-color: var(--background);
+  color: var(--primary-text);
   outline: none;
+  border: solid 1px white;
+  border-radius: 2px;
 }
 
 .dark ::selection {
@@ -116,29 +173,45 @@
 
 /* Welcome Page */
 .dark .welcome {
-  background-color: #111;
-  color: #bbb;
+  background-color: var(--background);
+  color: var(--primary-text);
+}
+
+.dark .welcome--sidebar {
+  background-color: var(--background-2);
+}
+
+.dark .welcome.mobile .welcome--searchbar--container {
+  background-color: var(--dark-blue-1);
+  border-bottom-color: var(--dark-blue-1);
 }
 
 .dark .entry--top--left {
-  color: #bbb;
+  color: var(--primary-text);
 }
 
 .dark .entry {
-  color: #bbb !important;
+  color: var(--primary-text);
 }
 
 .dark .file-uploader--wrapper.v2 {
-  background-color: #111;
+  background-color: rgba(0, 0, 0, 0);
 }
 
 .dark .filters .checkmark {
   background-color: transparent !important;
 }
 
-.dark .quickplay {
+.dark .entry {
+  background-color: var(--background-1);
+  border-color: rgba(255,255,255,0.3);
 }
 
 :root {
-  --dark-blue: rgb(36, 79, 115);
+  --dark-blue-1: rgb(36, 79, 115);
+  --dark-blue-2: #183a60;
+  --primary-text: rgba(255, 255, 255, 0.87);
+  --background: #121212;
+  --background-1: rgba(255, 255, 255, 0.05);
+  --background-2: rgba(255, 255, 255, 0.12);
 }

--- a/src/dark.css
+++ b/src/dark.css
@@ -15,8 +15,8 @@
 }
 
 .dark {
-  background-color: var(--background);
-  color: var(--primary-text);
+  background-color: var(--dark-background);
+  color: var(--dark-primary-text);
 }
 
 .dark .nav {
@@ -38,7 +38,7 @@
 }
 
 .dark .player--main--left--grid {
-  color: var(--primary-text);
+  color: var(--dark-primary-text);
 }
 
 .dark .grid--cell {
@@ -46,11 +46,11 @@
 }
 
 .dark .cell {
-  background-color: var(--background-2);
-  color: var(--primary-text);
+  background-color: var(--dark-background-2);
+  color: var(--dark-primary-text);
 }
 .dark .cell.black {
-  background-color: var(--background);
+  background-color: var(--dark-background);
 }
 
 .dark .cell.highlighted {
@@ -76,7 +76,7 @@
 }
 
 .dark .clues--list--scroll {
-  background-color: var(--background-1);
+  background-color: var(--dark-background-1);
 }
 
 .dark .clues--list--scroll--clue.selected {
@@ -84,12 +84,12 @@
 }
 
 .dark .clues--list--scroll--clue.half-selected {
-  background-color: var(--background-1);
+  background-color: var(--dark-background-1);
   border-left-color: var(--dark-blue-2);
 }
 
 .dark .chat--header--title {
-  color: var(--primary-text);
+  color: var(--dark-primary-text);
 }
 
 .dark .chat--system-message {
@@ -104,7 +104,7 @@
 }
 
 .dark .list-view--list--title {
-  background-color: var(--background);
+  background-color: var(--dark-background);
 }
 
 .dark ::-webkit-scrollbar-thumb {
@@ -113,7 +113,7 @@
 
 .dark .toolbar button {
   background-color: rgba(0, 0, 0, 0);
-  color: var(--primary-text);
+  color: var(--dark-primary-text);
 }
 
 .dark .toolbar {
@@ -121,7 +121,7 @@
   border-left: none;
   border-top: none;
   border-bottom-color: #888;
-  background-color: var(--background-2);
+  background-color: var(--dark-background-2);
 }
 
 .dark .toolbar--mobile {
@@ -131,7 +131,7 @@
 
 .dark .chat {
   border-color: #888;
-  background-color: var(--background-1);
+  background-color: var(--dark-background-1);
 }
 
 .dark .chat--header {
@@ -160,8 +160,8 @@
 }
 
 .dark input {
-  background-color: var(--background);
-  color: var(--primary-text);
+  background-color: var(--dark-background);
+  color: var(--dark-primary-text);
   outline: none;
   border: solid 1px white;
   border-radius: 2px;
@@ -173,12 +173,12 @@
 
 /* Welcome Page */
 .dark .welcome {
-  background-color: var(--background);
-  color: var(--primary-text);
+  background-color: var(--dark-background);
+  color: var(--dark-primary-text);
 }
 
 .dark .welcome--sidebar {
-  background-color: var(--background-2);
+  background-color: var(--dark-background-2);
 }
 
 .dark .welcome.mobile .welcome--searchbar--container {
@@ -187,11 +187,11 @@
 }
 
 .dark .entry--top--left {
-  color: var(--primary-text);
+  color: var(--dark-primary-text);
 }
 
 .dark .entry {
-  color: var(--primary-text);
+  color: var(--dark-primary-text);
 }
 
 .dark .file-uploader--wrapper.v2 {
@@ -203,15 +203,15 @@
 }
 
 .dark .entry {
-  background-color: var(--background-1);
+  background-color: var(--dark-background-1);
   border-color: rgba(255,255,255,0.3);
 }
 
 :root {
   --dark-blue-1: rgb(36, 79, 115);
   --dark-blue-2: #183a60;
-  --primary-text: rgba(255, 255, 255, 0.87);
-  --background: #121212;
-  --background-1: rgba(255, 255, 255, 0.05);
-  --background-2: rgba(255, 255, 255, 0.12);
+  --dark-primary-text: rgba(255, 255, 255, 0.87);
+  --dark-background: #121212;
+  --dark-background-1: rgba(255, 255, 255, 0.05);
+  --dark-background-2: rgba(255, 255, 255, 0.12);
 }


### PR DESCRIPTION
![Screenshot 2023-01-13 11 34 09 PM](https://user-images.githubusercontent.com/8743643/212456693-d5114c11-b97c-434b-9b9d-6c390fb7e9db.png)

Make some changes to dark mode colors following some guidelines from [https://m2.material.io/design/color/dark-theme.html](https://m2.material.io/design/color/dark-theme.html):
- Changed all primary text to white with 87% opacity
- Changed background to #121212
- Use 5% overlay for "elevated surfaces" and 12% for "menu surfaces" and the grid
- Use 47% opacity instead of the recommended 38% opacity for "disabled" text to maintain a 4.5:1 contrast ratio

Other color changes include
- Make black squares black and normal grid squares lighter.
- Make the selected square the users color
- Add a darker version of the referenced color
- Make highlighted row green on completion
- Modify some other colors to look better (in my opinion)

Also fixed an issue with the dark mode selection changing the height of the nav bar in mobile (when it overflows).

I'm sure this doesn't cover every possible change for a proper dark mode, but it should be a decent improvement over the current dark mode. I'm happy to modify any of these changes depending on what people think about it.
