### PR TITLE
Turn on confetti for mobile solves

### DIFF
--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -344,7 +344,7 @@ export default class Game extends Component {
         >
           {this.renderPlayer()}
         </Flex>
-        {this.game.solved && !this.props.mobile && <Confetti />}
+        {this.game.solved && <Confetti />}
       </Flex>
     );
   }


### PR DESCRIPTION
# What
Removes check for mobile when deciding to display confetti. Previously it wouldn't display confetti when on mobile, now always displays it.

# Why
Per issue #260 there seems to be consensus that performance issues are no longer a concern for mobile users. And confetti is fun! So let's turn it on : )