### PR TITLE
Add in iPUZ support

### DIFF
--- a/src/components/Upload/FileUploader.js
+++ b/src/components/Upload/FileUploader.js
@@ -7,6 +7,41 @@ import swal from '@sweetalert/with-react';
 
 import {hasShape} from '../../lib/jsUtils';
 import PUZtoJSON from '../../lib/converter/PUZtoJSON';
+import iPUZtoJSON from '../../lib/converter/iPUZtoJSON';
+import fileTypeGuesser from '../../lib/fileTypeGuesser';
+
+class InvalidFileTypeError extends Error {
+  constructor(fileType) {
+    const title = `Invalid .${fileType} file`;
+    super(title);
+    this.errorType = 'InvalidFileTypeError';
+    this.errorTitle = title;
+    this.errorText = `The uploaded file is not a valid .${fileType} file.`;
+    this.errorIcon = 'warning';
+  }
+}
+
+class UnknownFileTypeError extends Error {
+  constructor(fileType) {
+    const title = `Unknown file type: .${fileType}`;
+    super(title);
+    this.errorType = 'UnknownFileTypeError';
+    this.errorTitle = title;
+    this.errorText = 'The uploaded file could not be recognized';
+    this.errorIcon = 'warning';
+  }
+}
+
+class UnsupportedFileTypeError extends Error {
+  constructor(fileType) {
+    const title = `Unsupported file type: .${fileType}`;
+    super(title);
+    this.errorType = 'UnsupportedFileTypeError';
+    this.errorTitle = title;
+    this.errorText = 'The uploaded file is not currently supported';
+    this.errorIcon = 'warning';
+  }
+}
 
 export default class FileUploader extends Component {
   validPuzzle(puzzle) {
@@ -23,7 +58,6 @@ export default class FileUploader extends Component {
         down: {},
       },
     };
-
     return hasShape(puzzle, shape);
   }
 
@@ -52,23 +86,63 @@ export default class FileUploader extends Component {
     return result;
   }
 
+  convertIPUZ(readerResult) {
+    const {grid, info, circles, shades, across, down} = iPUZtoJSON(readerResult);
+
+    const result = {
+      grid,
+      circles,
+      shades,
+      info,
+      clues: {across, down},
+    };
+
+    return result;
+  }
+
+  attemptPuzzleConversion(readerResult, fileType) {
+    if (fileType === 'puz') {
+      return this.convertPUZ(readerResult);
+    } else if (fileType === 'ipuz') {
+      return this.convertIPUZ(readerResult);
+    } else if (fileType === 'jpz') {
+      throw new UnsupportedFileTypeError(fileType);
+    } else {
+      const guessedFileType = fileTypeGuesser(readerResult);
+      if (!guessedFileType) {
+        throw new UnknownFileTypeError(fileType);
+      } else {
+        return this.attemptPuzzleConversion(readerResult, guessedFileType);
+      }
+    }
+  }
+
   onDrop(acceptedFiles) {
     const file = acceptedFiles[0];
+    const fileType = file.name.split('.').pop();
     const reader = new FileReader();
     const {success, fail} = this.props;
     reader.addEventListener('loadend', () => {
       try {
-        const puzzle = this.convertPUZ(reader.result);
+        const puzzle = this.attemptPuzzleConversion(reader.result, fileType);
         if (this.validPuzzle(puzzle)) {
           success(puzzle);
         } else {
           fail();
         }
       } catch (e) {
+        let defaultTitle = 'Something went wrong';
+        let defaultText = `The error message was: ${e.message}`;
+        let defaultIcon = 'warning';
+
+        if (e?.errorTitle) defaultTitle = e.errorTitle;
+        if (e?.errorText) defaultText = e.errorText;
+        if (e?.errorIcon) defaultIcon = e.errorIcon;
+
         swal({
-          title: `Invalid .puz file`,
-          text: `The uploaded file is not a valid .puz file.`,
-          icon: 'warning',
+          title: defaultTitle,
+          text: defaultText,
+          icon: defaultIcon,
           buttons: 'OK',
           dangerMode: true,
         });

--- a/src/components/Upload/FileUploader.js
+++ b/src/components/Upload/FileUploader.js
@@ -166,7 +166,7 @@ export default class FileUploader extends Component {
         <div className={`file-uploader--wrapper ${v2 ? 'v2' : ''}`}>
           <div className="file-uploader--box">
             <MdFileUpload className="file-uploader--box--icon" />
-            Import .puz file
+            Import .puz or .ipuz file
           </div>
         </div>
       </Dropzone>

--- a/src/lib/converter/iPUZtoJSON.js
+++ b/src/lib/converter/iPUZtoJSON.js
@@ -1,0 +1,61 @@
+function convertCluesArray(initialCluesArray) {
+  const finalCluesArray = [];
+
+  for (let i = 0; i < initialCluesArray.length; i++) {
+    let item = initialCluesArray[i];
+    let number, stringClue;
+    if (Array.isArray(item)) {
+      number = parseInt(item[0]);
+      stringClue = item[1];
+    } else {
+      number = parseInt(item.number);
+      stringClue = item.clue;
+    }
+    finalCluesArray[parseInt(number)] = stringClue;
+  }
+
+  return finalCluesArray;
+}
+
+export default function iPUZtoJSON(readerResult) {
+  const jsonFromReader = JSON.parse(new TextDecoder().decode(readerResult));
+  const grid = jsonFromReader.solution.map((row) =>
+    row.map((cell) => (cell === null || cell === '#' ? '.' : cell))
+  );
+  const info = {
+    type: grid.length > 10 ? 'Daily Puzzle' : 'Mini Puzzle',
+    title: jsonFromReader.title || '',
+    author: jsonFromReader.author || '',
+    description: jsonFromReader.description || '',
+  };
+  const circles = [];
+  const shades = [];
+
+  jsonFromReader.puzzle.forEach((row, rowIndex) => {
+    row.forEach((cell, cellIndex) => {
+      if (typeof cell === 'object' && cell?.style?.shapebg && cell.style.shapebg === 'circle') {
+        circles.push(rowIndex * row.length + cellIndex);
+      }
+    });
+  });
+
+  let across = [];
+  let down = [];
+
+  Object.entries(jsonFromReader.clues).forEach(([direction, clues]) => {
+    if (direction === 'Across') {
+      across = convertCluesArray(clues);
+    } else if (direction === 'Down') {
+      down = convertCluesArray(clues);
+    }
+  });
+
+  return {
+    grid,
+    info,
+    circles,
+    shades,
+    across,
+    down,
+  };
+}

--- a/src/lib/fileTypeGuesser.js
+++ b/src/lib/fileTypeGuesser.js
@@ -1,0 +1,48 @@
+export default function fileTypeGuesser(readerResult) {
+  let isJSON = true;
+  let parsedJson;
+
+  try {
+    parsedJson = JSON.parse(new TextDecoder().decode(readerResult));
+  } catch (e) {
+    if (e.message.toLowerCase().includes('is not valid json')) {
+      isJSON = false;
+    }
+  }
+
+  if (isJSON && parsedJson?.version && parsedJson?.version.startsWith('http://ipuz.org')) {
+    return 'ipuz';
+  }
+
+  const puzMagicHeader = '4143524f535326444f574e00';
+
+  const otherMagicHeaders = {
+    '504b0304': {
+      mime: 'application/zip',
+      fileTypeGuess: 'jpz',
+    },
+    '3c3f786d': {
+      mime: 'text/xml',
+      fileTypeGuess: 'jpz',
+    },
+  };
+
+  const arr = new Uint8Array(readerResult).subarray(0, 14);
+  let foundPuzHeader = '';
+  let magicHeader = '';
+
+  for (let i = 0; i < arr.length; i++) {
+    if (i > 1 && i <= 14) {
+      foundPuzHeader += arr[i].toString(16).padStart(2, '0');
+    }
+    if (i < 4) {
+      magicHeader += arr[i].toString(16).padStart(2, '0');
+    }
+  }
+
+  if (foundPuzHeader === puzMagicHeader) {
+    return 'puz';
+  } else {
+    return otherMagicHeaders[magicHeader]?.fileTypeGuess;
+  }
+}


### PR DESCRIPTION
This PR adds fairly robust support in for iPUZ files, along with some utility classes to hopefully detect other crossword filetype support in the future (e.g. `jpz`).

Will add more comments inline in the PR soon!

Relevant background on iPUZ: http://www.ipuz.org/

See also #246 

## Screenshots / Demo:
![ipuz-support](https://user-images.githubusercontent.com/463175/230793058-be4da42b-a88a-46d1-aabe-3a0a19768edf.gif)
