### PR TITLE
Add stats

### DIFF
--- a/server/api/router.ts
+++ b/server/api/router.ts
@@ -3,6 +3,7 @@ import puzzleListRouter from './puzzle_list';
 import puzzleRouter from './puzzle';
 import gameRouter from './game';
 import recordSolveRouter from './record_solve';
+import statsRouter from './stats';
 
 const router = express.Router();
 
@@ -10,5 +11,6 @@ router.use('/puzzle_list', puzzleListRouter);
 router.use('/puzzle', puzzleRouter);
 router.use('/game', gameRouter);
 router.use('/record_solve', recordSolveRouter);
+router.use('/stats', statsRouter);
 
 export default router;

--- a/server/api/stats.ts
+++ b/server/api/stats.ts
@@ -1,0 +1,76 @@
+import {ListPuzzleStatsResponse, ListPuzzleStatsRequest} from '@shared/types';
+import express from 'express';
+import _ from 'lodash';
+import {getPuzzleSolves} from '../model/puzzle_solve';
+import type {SolvedPuzzleType} from '../model/puzzle_solve';
+
+const router = express.Router();
+
+type PuzzleSummaryStat = {
+  size: string;
+  n_puzzles_solved: number;
+  avg_solve_time: number;
+  best_solve_time: number;
+  best_solve_time_game: string;
+  avg_revealed_square_count: number;
+  avg_checked_square_count: number;
+};
+
+export function computePuzzleStats(puzzle_solves: SolvedPuzzleType[]): PuzzleSummaryStat[] {
+  const groupedSizes = _.groupBy(puzzle_solves, (ps) => ps.size);
+  const stats: PuzzleSummaryStat[] = [];
+  Object.entries(groupedSizes).forEach(([size, sizePuzzles]) => {
+    if (sizePuzzles.length === 0) {
+      return;
+    }
+    const bestPuzzle = _.minBy(sizePuzzles, (p) => p.time_taken_to_solve);
+    stats.push({
+      size,
+      n_puzzles_solved: sizePuzzles.length,
+      avg_solve_time: _.mean(_.map(sizePuzzles, (p) => p.time_taken_to_solve)),
+      best_solve_time_game: bestPuzzle!.gid,
+      best_solve_time: bestPuzzle!.time_taken_to_solve,
+      avg_revealed_square_count:
+        Math.round(_.mean(_.map(sizePuzzles, (p) => p.revealed_squares_count)) * 100) / 100,
+      avg_checked_square_count:
+        Math.round(_.mean(_.map(sizePuzzles, (p) => p.checked_squares_count)) * 100) / 100,
+    });
+  });
+
+  return stats.sort((a, b) => a.size.localeCompare(b.size));
+}
+
+router.get<{gids: string[]}, ListPuzzleStatsResponse, ListPuzzleStatsRequest>('/', async (req, res, next) => {
+  const gids = req.query.gids;
+  if (!Array.isArray(gids) || !_.every(gids, (it) => typeof it === 'string')) {
+    next(_.assign(new Error('gids are invalid'), {statusCode: 400}));
+  }
+  const puzzleSolves = await getPuzzleSolves(gids as string[]);
+  const puzzleStats = computePuzzleStats(puzzleSolves);
+  const stats = puzzleStats.map((stat) => ({
+    size: stat.size,
+    nPuzzlesSolved: stat.n_puzzles_solved,
+    avgSolveTime: stat.avg_solve_time,
+    bestSolveTime: stat.best_solve_time,
+    bestSolveTimeGameId: stat.best_solve_time_game,
+    avgCheckedSquareCount: stat.avg_checked_square_count,
+    avgRevealedSquareCount: stat.avg_revealed_square_count,
+  }));
+  const history = puzzleSolves.map((solve) => ({
+    puzzleId: solve.pid,
+    gameId: solve.gid,
+    title: solve.title,
+    size: solve.size,
+    dateSolved: solve.solved_time.format('YYYY-MM-DD'),
+    solveTime: solve.time_taken_to_solve,
+    checkedSquareCount: solve.checked_squares_count,
+    revealedSquareCount: solve.revealed_squares_count,
+  }));
+
+  res.json({
+    stats,
+    history,
+  });
+});
+
+export default router;

--- a/server/api/stats.ts
+++ b/server/api/stats.ts
@@ -42,6 +42,7 @@ export function computePuzzleStats(puzzle_solves: SolvedPuzzleType[]): PuzzleSum
 
 router.get<{gids: string[]}, ListPuzzleStatsResponse, ListPuzzleStatsRequest>('/', async (req, res, next) => {
   const gids = req.query.gids;
+  const startTime = Date.now();
   if (!Array.isArray(gids) || !_.every(gids, (it) => typeof it === 'string')) {
     next(_.assign(new Error('gids are invalid'), {statusCode: 400}));
   }
@@ -67,6 +68,8 @@ router.get<{gids: string[]}, ListPuzzleStatsResponse, ListPuzzleStatsRequest>('/
     revealedSquareCount: solve.revealed_squares_count,
   }));
 
+  const ms = Date.now() - startTime;
+  console.log(`overall /api/stats took ${ms}ms for ${puzzleSolves.length} solves`);
   res.json({
     stats,
     history,

--- a/server/model/puzzle_solve.ts
+++ b/server/model/puzzle_solve.ts
@@ -1,0 +1,90 @@
+import _ from 'lodash';
+import {pool} from './pool';
+import moment from 'moment';
+import {PuzzleJson} from '@shared/types';
+
+export type SolvedPuzzleType = {
+  pid: string;
+  gid: string;
+  solved_time: moment.Moment;
+  time_taken_to_solve: number;
+  revealed_squares_count: number;
+  checked_squares_count: number;
+  title: string;
+  size: string;
+};
+
+type RawFetchedPuzzleSolve = {
+  pid: string;
+  gid: string;
+  content: PuzzleJson;
+  solved_time: moment.Moment;
+  time_taken_to_solve: number;
+  event_type?: string;
+  event_payload?: {
+    params?: {scope?: {r: number; c: number}[]};
+  };
+};
+
+export async function getPuzzleSolves(gids: string[]): Promise<SolvedPuzzleType[]> {
+  const startTime = Date.now();
+  const {rows}: {rows: RawFetchedPuzzleSolve[]} = await pool.query(
+    `
+      SELECT
+        p.content,
+        ps.pid,
+        ps.gid,
+        ps.solved_time,
+        ps.time_taken_to_solve,
+        ge.event_type,
+        ge.event_payload
+      FROM puzzle_solves ps
+      JOIN puzzles p on ps.pid = p.pid
+      LEFT JOIN game_events ge
+        ON ps.gid = ge.gid AND ge.event_type IN ('check', 'reveal')
+      WHERE ps.gid = ANY($1)
+    `,
+    [gids]
+  );
+  const puzzleIds = new Map<string, RawFetchedPuzzleSolve>();
+  const revealedSquareByPuzzle = new Map<string, Set<string>>();
+  const checkedSquareByPuzzle = new Map<string, Set<string>>();
+  rows.forEach((row) => {
+    if (!puzzleIds.has(row.pid)) {
+      puzzleIds.set(row.pid, row);
+    }
+    const cells: string[] = row.event_payload?.params?.scope?.map((c) => JSON.stringify(c)) || [];
+
+    if (row.event_type === 'reveal') {
+      const revealedSquares = revealedSquareByPuzzle.get(row.pid) || new Set();
+      cells.forEach(revealedSquares.add, revealedSquares);
+      revealedSquareByPuzzle.set(row.pid, revealedSquares);
+    } else if (row.event_type === 'check') {
+      const checkedSquares = checkedSquareByPuzzle.get(row.pid) || new Set();
+      cells.forEach(checkedSquares.add, checkedSquares);
+      checkedSquareByPuzzle.set(row.pid, checkedSquares);
+    }
+  });
+
+  const puzzleSolves = Array.from(puzzleIds)
+    .map(([pid, puzzle]) => {
+      const title = puzzle.content.info.title;
+      const grid = puzzle.content.grid;
+      const width = grid.length;
+      const length = grid.length > 0 ? grid[0].length : 0;
+      return {
+        pid,
+        gid: puzzle.gid,
+        title,
+        size: `${width}x${length}`,
+        solved_time: moment(puzzle.solved_time, 'YYYY-MM-DD'),
+        time_taken_to_solve: Number(puzzle.time_taken_to_solve),
+        revealed_squares_count: (revealedSquareByPuzzle.get(puzzle.pid) || new Set()).size,
+        checked_squares_count: (checkedSquareByPuzzle.get(puzzle.pid) || new Set()).size,
+      };
+    })
+    .sort((a, b) => b.solved_time.utc().valueOf() - a.solved_time.utc().valueOf());
+  const ms = Date.now() - startTime;
+  console.log(`getPuzzleSolves took ${ms}ms`);
+  return puzzleSolves;
+}

--- a/server/model/puzzle_solve.ts
+++ b/server/model/puzzle_solve.ts
@@ -85,6 +85,6 @@ export async function getPuzzleSolves(gids: string[]): Promise<SolvedPuzzleType[
     })
     .sort((a, b) => b.solved_time.utc().valueOf() - a.solved_time.utc().valueOf());
   const ms = Date.now() - startTime;
-  console.log(`getPuzzleSolves took ${ms}ms`);
+  console.log(`getPuzzleSolves took ${ms}ms for ${gids.length} gids`);
   return puzzleSolves;
 }

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -1,39 +1,11 @@
 // ========== GET /api/stats ============
 
+import qs from 'qs';
 import {SERVER_URL} from './constants';
+import {ListPuzzleStatsRequest, ListPuzzleStatsResponse} from '../shared/types';
 
-interface Counts {
-  gameEvents: number;
-  activeGames: number;
-  connections: number;
-  bytesReceived: number;
-  bytesSent: number;
-}
-
-interface LiveStats {
-  serverStartDate: string;
-  gamesCount: number;
-  connectionsCount: number;
-}
-
-export interface TimeWindowStats {
-  name: string;
-  stats: {
-    windowStart: number;
-    prevCounts: Counts;
-    counts: Counts;
-    activeGids: string[];
-    percentComplete: number;
-  };
-}
-
-export interface AllStats {
-  timeWindowStats?: TimeWindowStats[];
-  liveStats?: LiveStats;
-}
-
-export async function fetchStats() {
-  const resp = await fetch(`${SERVER_URL}/api/stats`);
-  const allStats: AllStats = await resp.json();
+export async function fetchStats(query: ListPuzzleStatsRequest) {
+  const resp = await fetch(`${SERVER_URL}/api/stats?${qs.stringify(query)}`);
+  const allStats: ListPuzzleStatsResponse = await resp.json();
   return allStats;
 }

--- a/src/components/Toolbar/Clock.js
+++ b/src/components/Toolbar/Clock.js
@@ -3,6 +3,21 @@ import React, {Component} from 'react';
 import {getTime} from '../../store/firebase';
 import {MAX_CLOCK_INCREMENT} from '../../lib/timing';
 
+export const formatMilliseconds = (ms) => {
+  function pad2(num) {
+    let s = `${100}${num}`;
+    s = s.substr(s.length - 2);
+    return s;
+  }
+  let secs = Math.floor(ms / 1000);
+  let mins = Math.floor(secs / 60);
+  secs %= 60;
+  const hours = Math.floor(mins / 60);
+  mins %= 60;
+
+  return `${(hours ? `${hours}:` : '') + pad2(mins)}:${pad2(secs)}`;
+};
+
 export default class Clock extends Component {
   constructor() {
     super();
@@ -22,12 +37,6 @@ export default class Clock extends Component {
   }
 
   updateClock() {
-    function pad2(num) {
-      let s = `${100}${num}`;
-      s = s.substr(s.length - 2);
-      return s;
-    }
-
     const {pausedTime} = this.props;
     const start = this.props.startTime;
     const stop = this.props.stopTime;
@@ -50,15 +59,8 @@ export default class Clock extends Component {
       }
     }
 
-    let secs = Math.floor(clock / 1000);
-    let mins = Math.floor(secs / 60);
-    secs %= 60;
-    const hours = Math.floor(mins / 60);
-    mins %= 60;
-
-    const str = `${(hours ? `${hours}:` : '') + pad2(mins)}:${pad2(secs)}`;
     this.setState({
-      clock: str,
+      clock: formatMilliseconds(clock),
     });
   }
 

--- a/src/components/common/Nav.js
+++ b/src/components/common/Nav.js
@@ -103,8 +103,8 @@ export default function Nav({hidden, v2, canLogin, mobile, linkStyle, divRef}) {
         >
           Dark Mode (beta): {darkModePreferenceText(darkModePreference)}
         </div>
-        <div>
-          <a href="/stats">Stats</a>
+        <div className="nav--right stats">
+          <a href="/stats">Your stats</a>
         </div>
         <div className="nav--info" onClick={showInfo}>
           <i className="fa fa-info-circle" />

--- a/src/components/common/Nav.js
+++ b/src/components/common/Nav.js
@@ -96,12 +96,15 @@ export default function Nav({hidden, v2, canLogin, mobile, linkStyle, divRef}) {
         <Link to={fencing ? '/fencing' : '/'}>Down for a Cross</Link>
       </div>
       <div className="nav--right">
-		<div
+        <div
           className="molester-moon"
           style={darkModePreference !== '0' ? {opacity: 1} : {}}
           onClick={toggleMolesterMoons}
         >
           Dark Mode (beta): {darkModePreferenceText(darkModePreference)}
+        </div>
+        <div>
+          <a href="/stats">Stats</a>
         </div>
         <div className="nav--info" onClick={showInfo}>
           <i className="fa fa-info-circle" />

--- a/src/components/common/css/nav.css
+++ b/src/components/common/css/nav.css
@@ -24,6 +24,11 @@
   font-weight: 600;
 }
 
+.nav--right div a {
+  color: white;
+  margin-left: 40px;
+}
+
 .nav--right {
   margin-right: 10px;
   color: white;

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -66,7 +66,7 @@ const Stats: React.FC<{}> = () => {
                   <td>{avgSolveTime && formatMilliseconds(avgSolveTime)}</td>
                   <td>
                     {bestSolveTime && (
-                      <a href={`/beta/game/${bestSolveTimeGameId}`}>{formatMilliseconds(bestSolveTime)}</a>
+                      <a href={`/replay/${bestSolveTimeGameId}`}>{formatMilliseconds(bestSolveTime)}</a>
                     )}
                   </td>
                   <td>{avgCheckedSquareCount}</td>
@@ -93,7 +93,7 @@ const Stats: React.FC<{}> = () => {
               ({gameId, title, size, dateSolved, solveTime, checkedSquareCount, revealedSquareCount}) => (
                 <tr key={gameId}>
                   <td>
-                    <a href={`/beta/game/${gameId}`}>{title}</a>
+                    <a href={`/replay/${gameId}`}>{title}</a>
                     {` (${size})`}
                   </td>
                   <td>{dateSolved}</td>

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -23,8 +23,12 @@ const Stats: React.FC<{}> = () => {
 
   useEffect(() => {
     user.listUserHistory().then((history: any) => {
-      console.log(`keys: ${_.keys(history)}`);
-      fetchStats({gids: _.keys(history)}).then((s) => {
+      const recentGames = _.keys(history)
+        .filter((gid: string) => history[gid]?.solved)
+        .sort((gid: string) => history[gid]?.time)
+        .reverse()
+        .slice(0, 500);
+      fetchStats({gids: recentGames}).then((s) => {
         setStats(s);
       });
     });

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -1,110 +1,112 @@
-import React, {useEffect} from 'react';
-import {makeStyles} from '@material-ui/core/styles';
+import React, {useEffect, useState} from 'react';
 import _ from 'lodash';
-import {fetchStats, AllStats} from '../api/stats';
+import {fetchStats} from '../api/stats';
+import {ListPuzzleStatsResponse} from '../shared/types';
+import {getUser} from '../store/user';
+import Flex from 'react-flexview';
+import {Helmet} from 'react-helmet';
+import Nav from '../components/common/Nav';
+import {formatMilliseconds} from '../components/Toolbar/Clock';
+import {makeStyles} from '@material-ui/core';
 
 const useStyles = makeStyles({
-  page: {
-    padding: 16,
-  },
-  liveContainer: {
-    padding: 16,
-  },
-  timeWindowContainer: {
-    padding: 16,
-  },
   header: {
-    fontSize: '200%',
-  },
-  counts: {
-    fontWeight: 'bold',
-  },
-  table: {
-    borderCollapse: 'collapse',
-    textAlign: 'right',
+    textAlign: 'center',
   },
 });
 
 const Stats: React.FC<{}> = () => {
+  const user = getUser();
   const classes = useStyles();
-  const [allStats, setAllStats] = React.useState({} as AllStats);
+
+  const [stats, setStats] = useState<ListPuzzleStatsResponse | null>(null);
+
   useEffect(() => {
-    async function refresh() {
-      const allStats = await fetchStats();
-      setAllStats(allStats);
-    }
-    refresh();
-  }, []);
+    user.listUserHistory().then((history: any) => {
+      console.log(`keys: ${_.keys(history)}`);
+      fetchStats({gids: _.keys(history)}).then((s) => {
+        setStats(s);
+      });
+    });
+  }, [user]);
+
   return (
-    <div className={classes.page}>
-      {allStats.liveStats && (
-        <div className={classes.liveContainer}>
-          <div className={classes.header}>Live Stats</div>
-          <div>
-            Server last restarted
-            {allStats.liveStats.serverStartDate}
-          </div>
-          <div>
-            {allStats.liveStats.connectionsCount}
-            {' '}
-            {allStats.liveStats.connectionsCount === 1 ? 'user' : 'users'}
-            {' '}
-            online
-          </div>
-          <div>
-            {allStats.liveStats.gamesCount} 
-            {' '}
-            {allStats.liveStats.gamesCount === 1 ? 'game' : 'games'}
-            {' '}
-            being
-            played
-          </div>
-        </div>
-      )}
-      {_.map(allStats.timeWindowStats, ({name, stats}) => (
-        <div key={name} className={classes.timeWindowContainer}>
-          <div className={classes.header}>
-            {_.capitalize(name)}
-            {' '}
-            Stats
-          </div>
-          <table className={classes.table}>
-            <tbody>
-              <tr>
-                <th>Interval</th>
-                <th>Percent Complete</th>
-                <th>Active Games</th>
-                <th>Game Events</th>
-                <th>New Connections</th>
-                <th>Bytes Received</th>
-                <th>Bytes Sent</th>
-              </tr>
-              <tr>
-                <td>Previous Interval</td>
-                <td>100%</td>
-                <td>{stats.prevCounts.activeGames}</td>
-                <td>{stats.prevCounts.gameEvents}</td>
-                <td>{stats.prevCounts.connections}</td>
-                <td>{stats.prevCounts.bytesReceived}</td>
-                <td>{stats.prevCounts.bytesSent}</td>
-              </tr>
-              <tr>
-                <td>Current Interval</td>
-                <td>
-                  {(stats.percentComplete * 100).toFixed(2)}
-                  %
-                </td>
-                <td>{stats.counts.activeGames}</td>
-                <td>{stats.counts.gameEvents}</td>
-                <td>{stats.counts.connections}</td>
-                <td>{stats.counts.bytesReceived}</td>
-                <td>{stats.counts.bytesSent}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      ))}
-    </div>
+    <Flex column className="replays">
+      <Nav hidden={false} v2 canLogin={false} divRef={null} linkStyle={null} mobile={null} />
+      <Helmet>
+        <title>Stats</title>
+      </Helmet>
+
+      <div>
+        <h2 className={classes.header}>Stats</h2>
+        <table className="main-table">
+          <tbody>
+            <tr>
+              <th>Size</th>
+              <th># puzzles solved</th>
+              <th>Avg solve time</th>
+              <th>Best solve time</th>
+              <th>Avg squares checked</th>
+              <th>Avg squares revealed</th>
+            </tr>
+            {_.map(
+              stats?.stats,
+              ({
+                size,
+                nPuzzlesSolved,
+                avgSolveTime,
+                bestSolveTime,
+                bestSolveTimeGameId,
+                avgCheckedSquareCount,
+                avgRevealedSquareCount,
+              }) => (
+                <tr key={size}>
+                  <td>{size}</td>
+                  <td>{nPuzzlesSolved}</td>
+                  <td>{avgSolveTime && formatMilliseconds(avgSolveTime)}</td>
+                  <td>
+                    {bestSolveTime && (
+                      <a href={`/beta/game/${bestSolveTimeGameId}`}>{formatMilliseconds(bestSolveTime)}</a>
+                    )}
+                  </td>
+                  <td>{avgCheckedSquareCount}</td>
+                  <td>{avgRevealedSquareCount}</td>
+                </tr>
+              )
+            )}
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <h2 className={classes.header}>{`History (${stats?.history?.length || 0} total puzzles)`}</h2>
+        <table className="main-table">
+          <tbody>
+            <tr>
+              <th>Puzzle</th>
+              <th>Date solved</th>
+              <th>Solve time</th>
+              <th># checked squares</th>
+              <th># revealed squares</th>
+            </tr>
+            {_.map(
+              stats?.history,
+              ({gameId, title, size, dateSolved, solveTime, checkedSquareCount, revealedSquareCount}) => (
+                <tr key={gameId}>
+                  <td>
+                    <a href={`/beta/game/${gameId}`}>{title}</a>
+                    {` (${size})`}
+                  </td>
+                  <td>{dateSolved}</td>
+                  <td>{formatMilliseconds(solveTime)}</td>
+                  <td>{checkedSquareCount}</td>
+                  <td>{revealedSquareCount}</td>
+                </tr>
+              )
+            )}
+          </tbody>
+        </table>
+      </div>
+    </Flex>
   );
 };
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -101,6 +101,10 @@ export interface AddPuzzleResponse {
   pid: string;
 }
 
+export interface ListPuzzleStatsRequest {
+  gids: string[];
+}
+
 export interface ListPuzzleRequest {
   filter: ListPuzzleRequestFilters;
   page: number;
@@ -120,6 +124,28 @@ export interface ListPuzzleResponse {
     pid: string;
     content: PuzzleJson;
     stats: PuzzleStatsJson;
+  }[];
+}
+
+export interface ListPuzzleStatsResponse {
+  stats: {
+    size: string;
+    nPuzzlesSolved: number;
+    avgSolveTime: number;
+    bestSolveTime: number;
+    bestSolveTimeGameId: string;
+    avgCheckedSquareCount: number;
+    avgRevealedSquareCount: number;
+  }[];
+  history: {
+    puzzleId: string;
+    gameId: string;
+    title: string;
+    size: string;
+    dateSolved: string;
+    solveTime: number;
+    checkedSquareCount: number;
+    revealedSquareCount: number;
   }[];
 }
 


### PR DESCRIPTION
Similar to https://github.com/downforacross/downforacross.com/issues/247, I thought it could be helpful to see the times of one's previous solves. As far as I could tell, the stats modules weren't used, so I repurposed them for this.

Let me know what you think!

<img width="1628" alt="crossword_stats" src="https://github.com/downforacross/downforacross.com/assets/3457673/ffb3c232-6ec7-4317-ab2f-60b3916fb126">
