### PR TITLE
Prevent duplicate puzzles

### DIFF
--- a/server/api/puzzle.ts
+++ b/server/api/puzzle.ts
@@ -1,16 +1,29 @@
 import {AddPuzzleResponse, AddPuzzleRequest} from '@shared/types';
 import express from 'express';
 
-import {addPuzzle} from '../model/puzzle';
+import {addPuzzle, getMatchingPuzzle} from '../model/puzzle';
 
 const router = express.Router();
 
 router.post<{}, AddPuzzleResponse, AddPuzzleRequest>('/', async (req, res) => {
   console.log('got req', req.headers, req.body);
-  const pid = await addPuzzle(req.body.puzzle, req.body.isPublic, req.body.pid);
-  res.json({
-    pid,
-  });
+
+  try {
+    const pid = await addPuzzle(req.body.puzzle, req.body.isPublic, req.body.pid);
+    res.json({
+      pid,
+    });
+  } catch (err) {
+    if (err.code == '23505') {
+      const pid = await getMatchingPuzzle(req.body.puzzle);
+      console.log(`Unique constraint violated, attempt pid (${req.body.pid}) for existing pid (${pid})`);
+      res.status(400).json({duplicatePuzzle: pid});
+    } else {
+      console.error(err.message);
+      console.error(err.code);
+      res.status(400).json();
+    }
+  }
 });
 
 export default router;

--- a/server/sql/create_puzzles.sql
+++ b/server/sql/create_puzzles.sql
@@ -33,3 +33,5 @@ CREATE INDEX puzzle_pid_numeric_desc
     ON public.puzzles USING btree
     (pid_numeric DESC NULLS LAST)
     TABLESPACE pg_default;
+
+CREATE UNIQUE INDEX unique_puzzle_content ON public.puzzles (md5(content ->> 'grid'), md5(content -> 'clues' ->> 'down'), md5(content -> 'clues' ->> 'across')) WHERE pid > '30000' AND is_public;

--- a/src/components/Upload/Upload.js
+++ b/src/components/Upload/Upload.js
@@ -92,9 +92,30 @@ export default class Upload extends Component {
     return null;
   };
 
-  renderUploadSuccessModal = () => {
+  renderUploadSuccessModal = (response) => {
     swal.close();
-    if (!this.state.recentUnlistedPid) {
+    if (response.duplicatePuzzle) {
+      const url = `/beta/play/${response.duplicatePuzzle}`;
+      swal({
+        title: 'This puzzle already exists!',
+        icon: 'error',
+        content: (
+          <div className="swal-text swal-text--no-margin swal-text--text-align-center">
+            <p style={{marginTop: 10, marginBottom: 10}}>
+              Play the puzzle <a href={url}>here</a>
+            </p>
+          </div>
+        ),
+      });
+      // Shouldn't actually encounter this case, but just in case
+    } else if (!response.pid) {
+      this.props.onCreate && this.props.onCreate();
+      swal({
+        title: "Couldn't upload puzzle",
+        icon: 'error',
+        text: 'Encountered an error when uploading the puzzle.',
+      });
+    } else if (!this.state.recentUnlistedPid) {
       this.props.onCreate && this.props.onCreate();
       swal({
         title: 'Upload Success!',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -98,7 +98,8 @@ export interface AddPuzzleRequest {
 }
 
 export interface AddPuzzleResponse {
-  pid: string;
+  pid?: string;
+  duplicatePuzzle?: string;
 }
 
 export interface ListPuzzleStatsRequest {


### PR DESCRIPTION
For #139 and #15 

You'll need to create the index for this to take effect. I chose `30000` as the minimum `pid` to avoid enforcing unique constraints on existing data, and it appears to be an ID that'll be reached in the next week or two.

<img width="495" alt="duplicate_screenshot" src="https://github.com/downforacross/downforacross.com/assets/3457673/4a3bdc0e-d368-4dc9-acbb-00ba77b7e495">


I created another table locally called `puzzles_test` and verified that the index seems to be used:
```
# select count(*) from puzzles_test;
 count  
--------
 424649
(1 row)

# \d puzzles_test
                         Table "public.puzzles_test"
    Column    |            Type             | Collation | Nullable | Default 
--------------+-----------------------------+-----------+----------+---------
 uid          | text                        |           |          | 
 pid          | text                        |           | not null | 
 pid_numeric  | numeric                     |           |          | 
 is_public    | boolean                     |           |          | 
 uploaded_at  | timestamp without time zone |           |          | 
 times_solved | numeric                     |           |          | 0
 content      | jsonb                       |           |          | 
Indexes:
    "puzzles_test_pkey" PRIMARY KEY, btree (pid)
    "puzzle_test_pid_numeric_desc" btree (pid_numeric DESC NULLS LAST)
    "unique_puzzle_test_content" UNIQUE, btree (md5(content ->> 'grid'::text), md5((content -> 'clues'::text) ->> 'down'::text), md5((content -> 'clues'::text) ->> 'across'::text)) WHERE pid > '30000'::text AND is_public
Check constraints:
    "puzzles_test_times_solved_check" CHECK (times_solved >= 0::numeric)

# explain analyze SELECT
pid
FROM puzzles_test
WHERE pid > '5'
AND is_public
AND md5(content->>'grid'::text) = md5(('[["A","B"],["C","D"]]'::jsonb)::text)
AND md5(content->'clues'->>'down'::text) = md5(('{"down": ["z","y","x","w","v"]}'::jsonb)->>'down')
AND md5(content->'clues'->>'across'::text) = md5(('{"across": ["a","b","c","d","3"]}'::jsonb)->>'across');
-------------------
Index Scan using unique_puzzle_test_content on puzzles_test  (cost=0.42..8.44 rows=1 width=6) (actual time=0.021..0.022 rows=0 loops=1)
   Index Cond: ((md5((content ->> 'grid'::text)) = 'c56da16f5cfea23f45f4dad64b283dc4'::text) AND (md5(((content -> 'clues'::text) ->> 'down'::text)) = '55f362a61d73771fc88b5987a990c553'::text) AND (md5(((content -> 'clues'::text) ->> 'across'::text)) = '1b4d1966f41032490216c0f73ec9c4bf'::text))
   Filter: (pid > '5'::text)
 Planning Time: 0.280 ms
 Execution Time: 0.049 ms
(5 rows)
```
