### PR TITLE
Group existing duplicate puzzles in UI

### DIFF
--- a/server/api/puzzle_list.ts
+++ b/server/api/puzzle_list.ts
@@ -24,6 +24,7 @@ router.get<{}, ListPuzzleResponse>('/', async (req, res, next) => {
   const puzzles = rawPuzzleList.map((puzzle) => ({
     pid: puzzle.pid,
     content: puzzle.content,
+    puzzleHash: `${puzzle.down_md5}-${puzzle.across_md5}-${puzzle.grid_md5}`,
     stats: {numSolves: puzzle.times_solved},
   }));
   res.json({

--- a/server/model/puzzle.ts
+++ b/server/model/puzzle.ts
@@ -41,6 +41,9 @@ export async function listPuzzles(
     pid: string;
     content: PuzzleJson;
     times_solved: number;
+    down_md5: string;
+    across_md5: string;
+    grid_md5: string;
   }[]
 > {
   const startTime = Date.now();
@@ -61,7 +64,14 @@ export async function listPuzzles(
     .join('\n');
   const {rows} = await pool.query(
     `
-      SELECT pid, uploaded_at, content, times_solved
+      SELECT
+        pid,
+        uploaded_at,
+        content,
+        times_solved,
+        md5(content -> 'clues' ->> 'down') as down_md5,
+        md5(content -> 'clues' ->> 'across') as across_md5,
+        md5(content ->> 'grid') as grid_md5
       FROM puzzles
       WHERE is_public = true
       AND (content->'info'->>'type') = ANY($1)
@@ -79,6 +89,9 @@ export async function listPuzzles(
       is_public: boolean;
       content: PuzzleJson;
       times_solved: string;
+      down_md5: string;
+      across_md5: string;
+      grid_md5: string;
       // NOTE: numeric returns as string in pg-promise
       // See https://stackoverflow.com/questions/39168501/pg-promise-returns-integers-as-strings
     }) => ({

--- a/src/components/PuzzleList/Entry.tsx
+++ b/src/components/PuzzleList/Entry.tsx
@@ -5,33 +5,25 @@ import {MdRadioButtonUnchecked, MdCheckCircle} from 'react-icons/md';
 import {GiCrossedSwords} from 'react-icons/gi';
 import {Link} from 'react-router-dom';
 
+interface EntryPuzzle {
+  pid: string;
+  status: 'started' | 'solved';
+}
+
 export interface EntryProps {
   info: {
     type: string;
   };
   title: string;
   author: string;
-  pid: string;
-  status: 'started' | 'solved' | undefined;
-  stats: {
-    numSolves?: number;
-    solves?: Array<any>;
-  };
+  representativeId: string;
+  numSolves?: number;
+  aggregateStatus: 'started' | 'solved' | undefined;
   fencing?: boolean;
+  puzzles: EntryPuzzle[];
 }
 
 export default class Entry extends Component<EntryProps> {
-  handleClick = () => {
-    /*
-    this.setState({
-      expanded: !this.state.expanded,
-    });
-    this.props.onPlay(this.props.pid);
-    */
-  };
-
-  handleMouseLeave = () => {};
-
   get size() {
     const {type} = this.props.info;
     if (type === 'Daily Puzzle') {
@@ -44,17 +36,22 @@ export default class Entry extends Component<EntryProps> {
   }
 
   render() {
-    const {title, author, pid, status, stats, fencing} = this.props;
-    const numSolvesOld = _.size(stats?.solves || []);
-    const numSolves = numSolvesOld + (stats?.numSolves || 0);
+    const {title, author, representativeId, aggregateStatus, puzzles, fencing, numSolves} = this.props;
     const displayName = _.compact([author.trim(), this.size]).join(' | ');
-    return (
+
+    // we link parts of the entry to avoid nesting <a> elements
+    const linkify = (content: any, style: {color?: string} = {}) => (
       <Link
-        to={`/beta/play/${pid}${fencing ? '?fencing=1' : ''}`}
-        style={{textDecoration: 'none', color: 'initial'}}
+        to={`/beta/play/${representativeId}${fencing ? '?fencing=1' : ''}`}
+        style={{textDecoration: 'none', overflow: 'hidden', ...style}}
       >
-        <Flex className="entry" column onClick={this.handleClick} onMouseLeave={this.handleMouseLeave}>
-          <Flex className="entry--top--left">
+        {content}
+      </Link>
+    );
+    return (
+      <Flex className="entry" column>
+        <Flex className="entry--top--left">
+          {linkify(
             <Flex grow={0}>
               <p
                 style={{textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden'}}
@@ -63,28 +60,58 @@ export default class Entry extends Component<EntryProps> {
                 {displayName}
               </p>
             </Flex>
-            <Flex>
-              {status === 'started' && <MdRadioButtonUnchecked className="entry--icon" />}
-              {status === 'solved' && <MdCheckCircle className="entry--icon" />}
-              {status !== 'started' && status !== 'solved' && fencing && (
-                <GiCrossedSwords className="entry--icon fencing" />
-              )}
-            </Flex>
-          </Flex>
-          <Flex className="entry--main">
-            <Flex grow={0}>
-              <p style={{textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden'}} title={title}>
-                {title}
-              </p>
-            </Flex>
-          </Flex>
-          <Flex className="entry--details">
-            <p>
-              Solved {numSolves} {numSolves === 1 ? 'time' : 'times'}
-            </p>
+          )}
+          <Flex>
+            {puzzles.map((p) => {
+              return (
+                <span key={p.pid}>
+                  {p.status === 'started' && (
+                    <Link
+                      to={`/beta/play/${p.pid}${fencing ? '?fencing=1' : ''}`}
+                      style={{textDecoration: 'none', color: 'initial'}}
+                    >
+                      <MdRadioButtonUnchecked className="entry--icon" />
+                    </Link>
+                  )}
+                  {p.status === 'solved' && (
+                    <Link
+                      to={`/beta/play/${p.pid}${fencing ? '?fencing=1' : ''}`}
+                      style={{textDecoration: 'none', color: 'initial'}}
+                    >
+                      <MdCheckCircle className="entry--icon" />
+                    </Link>
+                  )}
+                  {p.status !== 'started' && p.status !== 'solved' && fencing && (
+                    <Link
+                      to={`/beta/play/${p.pid}${fencing ? '?fencing=1' : ''}`}
+                      style={{textDecoration: 'none', color: 'initial'}}
+                    >
+                      <GiCrossedSwords className="entry--icon fencing" />
+                    </Link>
+                  )}
+                </span>
+              );
+            })}
           </Flex>
         </Flex>
-      </Link>
+        {linkify(
+          <>
+            <Flex className="entry--main">
+              <Flex grow={0}>
+                <p style={{textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden'}} title={title}>
+                  {title}
+                </p>
+              </Flex>
+            </Flex>
+            <Flex className="entry--details">
+              <p>
+                Solved {numSolves} {numSolves === 1 ? 'time' : 'times'}
+              </p>
+            </Flex>
+          </>,
+          {color: 'initial'}
+        )}
+      </Flex>
     );
   }
 }

--- a/src/components/PuzzleList/NewPuzzleList.tsx
+++ b/src/components/PuzzleList/NewPuzzleList.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, {useEffect, useRef, useState} from 'react';
-import {PuzzleJson, PuzzleStatsJson, ListPuzzleRequestFilters} from '../../shared/types';
+import {PuzzleJson, PuzzleStatsJson, ListPuzzleRequestFilters, ListedPuzzle} from '../../shared/types';
 import {fetchPuzzleList} from '../../api/puzzle_list';
 import './css/puzzleList.css';
 import Entry, {EntryProps} from './Entry';
@@ -20,19 +20,46 @@ interface NewPuzzleListProps {
   fencing?: boolean;
 }
 
+const summarizePuzzles = (
+  puzzles: ListedPuzzle[],
+  puzzleStatuses: PuzzleStatuses
+): {
+  representativePuzzle: ListedPuzzle;
+  puzzlesToRender: ListedPuzzle[];
+  aggregateStatus: 'solved' | 'started' | undefined;
+} => {
+  let representativePuzzle;
+  let puzzlesToRender;
+
+  const solvedPuzzles = puzzles.filter((p) => puzzleStatuses[p.pid] === 'solved');
+  const startedPuzzles = puzzles.filter((p) => puzzleStatuses[p.pid] === 'started');
+  let aggregateStatus: 'solved' | 'started' | undefined;
+  if (solvedPuzzles.length > 0) {
+    // if the user has solved a puzzle instance, use that as the representative puzzle
+    representativePuzzle = solvedPuzzles[0];
+    puzzlesToRender = puzzles.filter((p) => puzzleStatuses[p.pid]);
+    aggregateStatus = 'solved';
+  } else if (startedPuzzles.length > 0) {
+    // or, if the user has started a puzzle instance, use that as the representative puzzle
+    representativePuzzle = startedPuzzles[0];
+    puzzlesToRender = puzzles.filter((p) => puzzleStatuses[p.pid]);
+    aggregateStatus = 'started';
+  } else {
+    // otherwise, use the most commonly solved instance
+    const mostSolvedPuzzle = _.maxBy(puzzles, (p) => p.stats.numSolves)!;
+    representativePuzzle = mostSolvedPuzzle;
+    puzzlesToRender = [mostSolvedPuzzle];
+  }
+  return {representativePuzzle, puzzlesToRender, aggregateStatus};
+};
+
 const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [fullyLoaded, setFullyLoaded] = useState<boolean>(false);
   const [page, setPage] = useState<number>(0);
   const pageSize = 50;
-  const [puzzles, setPuzzles] = useState<
-    {
-      pid: string;
-      content: PuzzleJson;
-      stats: PuzzleStatsJson;
-    }[]
-  >([]);
+  const [puzzles, setPuzzles] = useState<ListedPuzzle[]>([]);
   const fullyScrolled = (): boolean => {
     if (!containerRef.current) return false;
     const {scrollTop, scrollHeight, clientHeight} = containerRef.current;
@@ -42,14 +69,7 @@ const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
 
   const fetchMore = React.useCallback(
     _.throttle(
-      async (
-        currentPuzzles: {
-          pid: string;
-          content: PuzzleJson;
-          stats: PuzzleStatsJson;
-        }[],
-        currentPage: number
-      ) => {
+      async (currentPuzzles: ListedPuzzle[], currentPage: number) => {
         if (loading) return;
         setLoading(true);
         const nextPage = await fetchPuzzleList({page: currentPage, pageSize, filter: props.filter});
@@ -82,27 +102,54 @@ const NewPuzzleList: React.FC<NewPuzzleListProps> = (props) => {
 
   const puzzleData: {
     entryProps: EntryProps;
-  }[] = puzzles
-    .map((puzzle) => ({
-      entryProps: {
-        info: {
-          type: puzzle.content.info.type!, // XXX not the best form
+  }[] = _.chain(puzzles)
+    .groupBy((p) => p.puzzleHash)
+    .map((puzzles, _hash) => {
+      const {representativePuzzle, aggregateStatus, puzzlesToRender} = summarizePuzzles(
+        puzzles,
+        props.puzzleStatuses
+      );
+      return {
+        entryProps: {
+          info: {
+            type: representativePuzzle.content.info.type!, // XXX not the best form
+          },
+          status: aggregateStatus,
+          representativeId: representativePuzzle.pid,
+          aggregateStatus: aggregateStatus,
+          numSolves: representativePuzzle.stats.numSolves || 0,
+          title: representativePuzzle.content.info.title,
+          author: representativePuzzle.content.info.author,
+          fencing: props.fencing,
+          puzzles: puzzlesToRender.map((puzzle) => ({
+            pid: puzzle.pid,
+            status: props.puzzleStatuses[puzzle.pid],
+          })),
         },
-        title: puzzle.content.info.title,
-        author: puzzle.content.info.author,
-        pid: puzzle.pid,
-        stats: puzzle.stats,
-        status: props.puzzleStatuses[puzzle.pid],
-        fencing: props.fencing,
-      },
-    }))
+      };
+    })
     .filter((data) => {
-      const mappedStatus = {
-        undefined: 'New' as const,
+      const statusMapping = {
         solved: 'Complete' as const,
         started: 'In progress' as const,
-      }[data.entryProps.status];
+      };
+      let mappedStatus: 'New' | 'Complete' | 'In progress';
+      if (data.entryProps.status) {
+        mappedStatus = statusMapping[data.entryProps.status];
+      } else {
+        mappedStatus = 'New';
+      }
       return props.statusFilter[mappedStatus];
+    })
+    .value()
+    .sort((p1, p2) => {
+      // we sort the results by pid so that scrolling doesn't cause the results to shuffle
+      const p1Id = parseInt(p1.entryProps.representativeId);
+      const p2Id = parseInt(p2.entryProps.representativeId);
+      if (p1Id && p2Id) {
+        return p2Id - p1Id;
+      }
+      return p2.entryProps.representativeId.localeCompare(p1.entryProps.representativeId);
     });
   return (
     <div

--- a/src/pages/css/welcome.css
+++ b/src/pages/css/welcome.css
@@ -112,7 +112,6 @@
 }
 
 .entry {
-  cursor: pointer;
   white-space: nowrap;
   position: relative;
   border: 1px solid silver;
@@ -127,6 +126,13 @@
 
 .mobile .entry {
   width: 80vw;
+}
+
+.entry--top--left > a {
+  font-size: 15px;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.7);
+  justify-content: space-between;
 }
 
 .entry--top--left {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -119,12 +119,15 @@ export interface ListPuzzleRequestFilters {
   nameOrTitleFilter: string;
 }
 
+export interface ListedPuzzle {
+  pid: string;
+  puzzleHash: string;
+  content: PuzzleJson;
+  stats: PuzzleStatsJson;
+}
+
 export interface ListPuzzleResponse {
-  puzzles: {
-    pid: string;
-    content: PuzzleJson;
-    stats: PuzzleStatsJson;
-  }[];
+  puzzles: ListedPuzzle[];
 }
 
 export interface ListPuzzleStatsResponse {


### PR DESCRIPTION
Follow up to https://github.com/downforacross/downforacross.com/pull/276

The other PR prevents new duplicates. This groups existing duplicates in the UI. Users who have already started or solved puzzles will still be able to see their results, but users who haven't touched a puzzle before won't see that there's duplicates.

<img width="1430" alt="Screenshot 2023-07-04 at 10 33 26 AM" src="https://github.com/downforacross/downforacross.com/assets/3457673/f0cd915b-4fde-4bd0-848d-d3c3d7b2298f">