### PR TITLE
Implement link previews

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,29 +7,45 @@ function isGameUrl(url) {
     return split.length >= 3 && split[2] === 'game'
 }
 
+const linkExpanderUserAgents = [
+    'Discordbot',
+    'Slackbot-LinkExpanding'
+]
+
+function islinkExpanderBot(userAgent) {
+    return linkExpanderUserAgents.some(ua => userAgent.includes(ua))
+}
+
 export default function middleware(req: Request) {
     const url = new URL(req.url)
 
-    if (isAsset(url) || !isGameUrl(url)) {
+    if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers['user-agent'])) {
         return new Response(null, {
             headers: { 'x-middleware-next': '1' },
         })
     }
 
-    const oEmbedEndpoint = `${url.origin}'/api/oembed?url=${encodeURI(url.toString())}`
-    const linkHeaderContent = [
-        `<${oEmbedEndpoint}>`,
-        'rel="alternate"',
-        'type="application/json+oembed"',
-        'title="placeholder"'
-    ]
+    // const oEmbedEndpoint = `${url.origin}'/api/oembed?url=${encodeURI(url.toString())}`
+    // const linkHeaderContent = [
+    //     `<${oEmbedEndpoint}>`,
+    //     'rel="alternate"',
+    //     'type="application/json+oembed"',
+    //     'title="placeholder"'
+    // ]
 
-    console.log(linkHeaderContent)
+    // console.log(linkHeaderContent)
+
+    // return new Response(null, {
+    //     headers: {
+    //         'x-middleware-next': '1',
+    //         'Link': linkHeaderContent.join('; '),
+    //     },
+    // })
 
     return new Response(null, {
+        status: 307,
         headers: {
-            'x-middleware-next': '1',
-            'Link': linkHeaderContent.join('; '),
+            'Location': 'https://www.google.com', // Testing UA-based redirects
         },
     })
-}
+}   

--- a/middleware.ts
+++ b/middleware.ts
@@ -13,11 +13,11 @@ function isGameUrl(url) {
 export default function middleware(req: Request) {
     const url = new URL(req.url)
 
-    if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers.get('user-agent') as string)) {
-        return new Response(null, {
-            headers: { 'x-middleware-next': '1' },
-        })
-    }
+    // if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers.get('user-agent') as string)) {
+    //     return new Response(null, {
+    //         headers: { 'x-middleware-next': '1' },
+    //     })
+    // }
 
     return new Response(SERVER_URL, {
         // status: 307,

--- a/middleware.ts
+++ b/middleware.ts
@@ -18,16 +18,8 @@ function islinkExpanderBot(userAgent) {
 
 export default function middleware(req: Request) {
     const url = new URL(req.url)
-    try {
-        console.log(islinkExpanderBot(req.headers.get('user-agent')))
-    } catch (error) {
-        return new Response(error.toString() + '\n' + JSON.stringify([...req.headers]), {
-            status: 501,
-        })
-    }
 
-    // if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers['user-agent'])) {
-    if (isAsset(url) || !isGameUrl(url)) {
+    if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers.get('user-agent'))) {
         return new Response(null, {
             headers: { 'x-middleware-next': '1' },
         })

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,22 +2,34 @@ function isAsset(url) {
     return /\.(png|jpe?g|gif|css|js|svg|ico|map|json)$/i.test(url.pathname)
 }
 
+function isGameUrl(url) {
+    const split = url.pathname.split('/')
+    return split.length >= 3 && split[2] === 'game'
+}
+
 export default function middleware(req: Request) {
     const url = new URL(req.url)
 
-    if (isAsset(url)) {
+    if (isAsset(url) || !isGameUrl(url)) {
         return new Response(null, {
             headers: { 'x-middleware-next': '1' },
         })
     }
 
-    const headers = new Headers({ 'x-custom-1': 'value-1' })
-    headers.set('x-custom-2', 'value-2')
+    const oEmbedEndpoint = `${url.origin}'/api/oembed?url=${encodeURI(url.toString())}`
+    const linkHeaderContent = [
+        `<${oEmbedEndpoint}>`,
+        'rel="alternate"',
+        'type="application/json+oembed"',
+        'title="placeholder"'
+    ]
+
+    console.log(linkHeaderContent)
 
     return new Response(null, {
         headers: {
             'x-middleware-next': '1',
-            ...Object.fromEntries(headers),
+            'Link': linkHeaderContent.join('; '),
         },
     })
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,6 +19,8 @@ function islinkExpanderBot(userAgent) {
 export default function middleware(req: Request) {
     const url = new URL(req.url)
 
+    console.log(req.headers['user-agent'])
+
     // if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers['user-agent'])) {
     if (isAsset(url) || !isGameUrl(url)) {
         return new Response(null, {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,3 +1,6 @@
+import { islinkExpanderBot } from "./utils/link_preview_util"
+import { SERVER_URL } from "./src/api/constants"
+
 function isAsset(url) {
     return /\.(png|jpe?g|gif|css|js|svg|ico|map|json)$/i.test(url.pathname)
 }
@@ -7,45 +10,19 @@ function isGameUrl(url) {
     return split.length >= 3 && split[2] === 'game'
 }
 
-const linkExpanderUserAgents = [
-    'Discordbot',
-    'Slackbot-LinkExpanding'
-]
-
-function islinkExpanderBot(userAgent) {
-    return linkExpanderUserAgents.some(ua => userAgent.includes(ua))
-}
-
 export default function middleware(req: Request) {
     const url = new URL(req.url)
 
-    if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers.get('user-agent'))) {
+    if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers.get('user-agent') as string)) {
         return new Response(null, {
             headers: { 'x-middleware-next': '1' },
         })
     }
 
-    // const oEmbedEndpoint = `${url.origin}'/api/oembed?url=${encodeURI(url.toString())}`
-    // const linkHeaderContent = [
-    //     `<${oEmbedEndpoint}>`,
-    //     'rel="alternate"',
-    //     'type="application/json+oembed"',
-    //     'title="placeholder"'
-    // ]
-
-    // console.log(linkHeaderContent)
-
-    // return new Response(null, {
-    //     headers: {
-    //         'x-middleware-next': '1',
-    //         'Link': linkHeaderContent.join('; '),
-    //     },
-    // })
-
-    return new Response(null, {
-        status: 307,
-        headers: {
-            'Location': 'https://www.google.com', // Testing UA-based redirects
-        },
+    return new Response(SERVER_URL, {
+        // status: 307,
+        // headers: {
+        //     'Location': `https://www.google.com?url=${url}`, // temp url for testing, needs to be replaced by api.foracross.com
+        // },
     })
 }   

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,7 +22,7 @@ export default function middleware(req: Request) {
     try {
         console.log(islinkExpanderBot(req.headers['user-agent']))
     } catch (error) {
-        return new Response(error.toString(), {
+        return new Response(error.toString() + '\n' + JSON.stringify(req.headers), {
             status: 501,
         })
     }

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,7 +19,8 @@ function islinkExpanderBot(userAgent) {
 export default function middleware(req: Request) {
     const url = new URL(req.url)
 
-    if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers['user-agent'])) {
+    // if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers['user-agent'])) {
+    if (isAsset(url) || !isGameUrl(url)) {
         return new Response(null, {
             headers: { 'x-middleware-next': '1' },
         })

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,7 +22,7 @@ export default function middleware(req: Request) {
     try {
         console.log(islinkExpanderBot(req.headers['user-agent']))
     } catch (error) {
-        return new Response(error.toString() + '\n' + JSON.stringify(req.headers), {
+        return new Response(error.toString() + '\n' + JSON.stringify(req.headers) + '\n' + JSON.stringify(req), {
             status: 501,
         })
     }

--- a/middleware.ts
+++ b/middleware.ts
@@ -18,9 +18,8 @@ function islinkExpanderBot(userAgent) {
 
 export default function middleware(req: Request) {
     const url = new URL(req.url)
-
     try {
-        console.log(islinkExpanderBot(req.headers['user-agent']))
+        console.log(islinkExpanderBot(req.headers.get('user-agent')))
     } catch (error) {
         return new Response(error.toString() + '\n' + JSON.stringify([...req.headers]), {
             status: 501,

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,7 +22,7 @@ export default function middleware(req: Request) {
     try {
         console.log(islinkExpanderBot(req.headers['user-agent']))
     } catch (error) {
-        return new Response(error.toString() + '\n' + JSON.stringify(req.headers) + '\n' + JSON.stringify(req), {
+        return new Response(error.toString() + '\n' + JSON.stringify([...req.headers]), {
             status: 501,
         })
     }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,4 @@
 import { islinkExpanderBot } from "./utils/link_preview_util"
-import { SERVER_URL } from "./src/api/constants"
 
 function isAsset(url) {
     return /\.(png|jpe?g|gif|css|js|svg|ico|map|json)$/i.test(url.pathname)
@@ -13,16 +12,17 @@ function isGameUrl(url) {
 export default function middleware(req: Request) {
     const url = new URL(req.url)
 
-    // if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers.get('user-agent') as string)) {
-    //     return new Response(null, {
-    //         headers: { 'x-middleware-next': '1' },
-    //     })
-    // }
-
-    return new Response(SERVER_URL, {
-        // status: 307,
-        // headers: {
-        //     'Location': `https://www.google.com?url=${url}`, // temp url for testing, needs to be replaced by api.foracross.com
-        // },
+    if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers.get('user-agent') as string)) {
+        return new Response(null, {
+            headers: { 'x-middleware-next': '1' },
+        })
+    }
+    
+    // crawled by link expander bot, so redirect to link preview endpoint for this game URL
+    return new Response(null, { 
+        status: 307,
+        headers: {
+            'Location': `https://api.foracross.com/api/link_preview?url=${url}` // vercel middleware can't really be tested in dev so just hardcoding to prod endpoint
+        },
     })
 }   

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,23 @@
+function isAsset(url) {
+    return /\.(png|jpe?g|gif|css|js|svg|ico|map|json)$/i.test(url.pathname)
+}
+
+export default function middleware(req: Request) {
+    const url = new URL(req.url)
+
+    if (isAsset(url)) {
+        return new Response(null, {
+            headers: { 'x-middleware-next': '1' },
+        })
+    }
+
+    const headers = new Headers({ 'x-custom-1': 'value-1' })
+    headers.set('x-custom-2', 'value-2')
+
+    return new Response(null, {
+        headers: {
+            'x-middleware-next': '1',
+            ...Object.fromEntries(headers),
+        },
+    })
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,7 +19,14 @@ function islinkExpanderBot(userAgent) {
 export default function middleware(req: Request) {
     const url = new URL(req.url)
 
-    console.log(req.headers['user-agent'])
+    try {
+        console.log(islinkExpanderBot(req.headers['user-agent']))
+    } catch (error) {
+        return new Response(null, {
+            status: 501,
+            statusText: error.toString()
+        })
+    }
 
     // if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers['user-agent'])) {
     if (isAsset(url) || !isGameUrl(url)) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,9 +22,8 @@ export default function middleware(req: Request) {
     try {
         console.log(islinkExpanderBot(req.headers['user-agent']))
     } catch (error) {
-        return new Response(null, {
+        return new Response(error.toString(), {
             status: 501,
-            statusText: error.toString()
         })
     }
 

--- a/server/api/link_preview.ts
+++ b/server/api/link_preview.ts
@@ -1,0 +1,54 @@
+import express from 'express';
+import _ from 'lodash'
+
+import { InfoJson } from '../../src/shared/types';
+import { getGameInfo } from '../model/game';
+import { islinkExpanderBot } from "../../utils/link_preview_util"
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+    console.log('got req', req.headers, req.body);
+    let gameUrl;
+
+    try {
+        gameUrl = new URL(req.query.url as string);
+    } catch (_) {
+        res.sendStatus(400);
+        return
+    }
+
+    const gid = gameUrl.pathname.split('/')[3]
+    const info = await getGameInfo(gid) as InfoJson;
+
+    if (_.isEmpty(info)) {
+        res.sendStatus(404);
+        return
+    }
+
+    if (!islinkExpanderBot(req.headers['user-agent'] as string)) { // In case a human accesses this endpoint
+        res.redirect(gameUrl.href)
+        return
+    }
+
+    // OGP doesn't support an author property, so we need to delegate to the oEmbed endpoint
+    const oembedEndpointUrl = `${req.protocol}://${req.get('host')}/api/oembed?author=${encodeURIComponent(info.author)}` 
+
+    // https://ogp.me
+    res.send(String.raw`
+        <html prefix="og: https://ogp.me/ns/website#">
+            <head>
+                <title>${info.title}</title>
+                <meta property="og:title" content="${info.title}" />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="${gameUrl.href}" />
+                <meta property="og:description" content="${info.description}" />
+                <meta property="og:site_name" content="downforacross.com" />
+                <link type="application/json+oembed" href=${oembedEndpointUrl} />
+                <meta name="theme-color" content="#6aa9f4">
+            </head>
+        </html>
+    `)
+});
+
+export default router;

--- a/server/api/oembed.ts
+++ b/server/api/oembed.ts
@@ -1,36 +1,18 @@
 import express from 'express';
 import _ from 'lodash'
 
-import { InfoJson } from '../../src/shared/types';
-
-import { getGameInfo } from '../model/game';
-
 const router = express.Router();
 
 router.get('/', async (req, res) => {
     console.log('got req', req.headers, req.body);
-    let gameUrl;
 
-    try {
-        gameUrl = new URL(req.query.url as string);
-    } catch (_) {
-        res.sendStatus(400);
-        return
-    }
-
-    const gid = gameUrl.pathname.split('/')[3]
-    const info = await getGameInfo(gid) as InfoJson;
-
-    if (_.isEmpty(info)) {
-        res.sendStatus(400);
-        return
-    }
+    const author = req.query.author as string
 
     // https://oembed.com/#section2.3
     res.json({
         type: 'link',
         version: '1.0',
-        title: info.title
+        author_name: author,
     });
 });
 

--- a/server/api/oembed.ts
+++ b/server/api/oembed.ts
@@ -1,0 +1,37 @@
+import express from 'express';
+import _ from 'lodash'
+
+import { InfoJson } from '../../src/shared/types';
+
+import { getGameInfo } from '../model/game';
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+    console.log('got req', req.headers, req.body);
+    let gameUrl;
+
+    try {
+        gameUrl = new URL(req.query.url as string);
+    } catch (_) {
+        res.sendStatus(400);
+        return
+    }
+
+    const gid = gameUrl.pathname.split('/')[3]
+    const info = await getGameInfo(gid) as InfoJson;
+
+    if (_.isEmpty(info)) {
+        res.sendStatus(400);
+        return
+    }
+
+    // https://oembed.com/#section2.3
+    res.json({
+        type: 'link',
+        version: '1.0',
+        title: info.title
+    });
+});
+
+export default router;

--- a/server/api/router.ts
+++ b/server/api/router.ts
@@ -5,6 +5,7 @@ import gameRouter from './game';
 import recordSolveRouter from './record_solve';
 import statsRouter from './stats';
 import oEmbedRouter from './oembed'
+import linkPreviewRouter from './link_preview'
 
 const router = express.Router();
 
@@ -14,5 +15,6 @@ router.use('/game', gameRouter);
 router.use('/record_solve', recordSolveRouter);
 router.use('/stats', statsRouter);
 router.use('/oembed', oEmbedRouter);
+router.use('/link_preview', linkPreviewRouter);
 
 export default router;

--- a/server/api/router.ts
+++ b/server/api/router.ts
@@ -4,6 +4,7 @@ import puzzleRouter from './puzzle';
 import gameRouter from './game';
 import recordSolveRouter from './record_solve';
 import statsRouter from './stats';
+import oEmbedRouter from './oembed'
 
 const router = express.Router();
 
@@ -12,5 +13,6 @@ router.use('/puzzle', puzzleRouter);
 router.use('/game', gameRouter);
 router.use('/record_solve', recordSolveRouter);
 router.use('/stats', statsRouter);
+router.use('/oembed', oEmbedRouter);
 
 export default router;

--- a/server/model/game.ts
+++ b/server/model/game.ts
@@ -13,6 +13,18 @@ export async function getGameEvents(gid: string) {
   return events;
 }
 
+export async function getGameInfo(gid: string) {
+  const res = await pool.query('SELECT event_payload FROM game_events WHERE gid=$1 AND event_type=\'create\'', [gid]);
+  if (res.rowCount != 1) {
+    console.log(`Could not find info for game ${gid}`);
+    return {}
+  }
+
+  const info = res.rows[0].event_payload.params.game.info;
+  console.log(`${gid} game info: ${JSON.stringify(info)}`);
+  return info;
+}
+
 export interface GameEvent {
   user?: string; // always null actually
   timestamp: number;

--- a/utils/link_preview_util.ts
+++ b/utils/link_preview_util.ts
@@ -1,0 +1,8 @@
+const linkExpanderUserAgents = [
+    'Discordbot',
+    'Slackbot-LinkExpanding'
+]
+
+export function islinkExpanderBot(userAgent: string) {
+    return linkExpanderUserAgents.some(ua => userAgent.includes(ua))
+}


### PR DESCRIPTION
This is a draft/in-progress PR, so feel free to disregard it.

Currently working on implementing link previews (also known as "embeds") for DFAC game URLs sent in platforms such as Discord and Slack. By setting Link headers that conform to the [oEmbed spec](https://oembed.com/#section4) in our responses, these platforms can read the headers and display link previews that contain puzzle metadata such as title and description.

These headers are being appended using a feature called Vercel middleware, which is why this draft PR was created (to check the response headers in the deployed Vercel preview).
