### PR TITLE
Implement link previews

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,28 @@
+import { islinkExpanderBot } from "./utils/link_preview_util"
+
+function isAsset(url) {
+    return /\.(png|jpe?g|gif|css|js|svg|ico|map|json)$/i.test(url.pathname)
+}
+
+function isGameUrl(url) {
+    const split = url.pathname.split('/')
+    return split.length >= 3 && split[2] === 'game'
+}
+
+export default function middleware(req: Request) {
+    const url = new URL(req.url)
+
+    if (isAsset(url) || !isGameUrl(url) || !islinkExpanderBot(req.headers.get('user-agent') as string)) {
+        return new Response(null, {
+            headers: { 'x-middleware-next': '1' },
+        })
+    }
+    
+    // crawled by link expander bot, so redirect to link preview endpoint for this game URL
+    return new Response(null, { 
+        status: 307,
+        headers: {
+            'Location': `https://api.foracross.com/api/link_preview?url=${url}` // vercel middleware can't really be tested in dev so just hardcoding to prod endpoint
+        },
+    })
+}   

--- a/server/api/link_preview.ts
+++ b/server/api/link_preview.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 
 import { InfoJson } from '../../src/shared/types';
 import { getGameInfo } from '../model/game';
-import { islinkExpanderBot } from "../../utils/link_preview_util"
+import { islinkExpanderBot, isFBMessengerCrawler } from "../../utils/link_preview_util"
 
 const router = express.Router();
 
@@ -26,20 +26,27 @@ router.get('/', async (req, res) => {
         return
     }
 
-    if (!islinkExpanderBot(req.headers['user-agent'] as string)) { // In case a human accesses this endpoint
+    const ua = req.headers['user-agent'] as string
+
+    if (!islinkExpanderBot(ua)) { // In case a human accesses this endpoint
         res.redirect(gameUrl.href)
         return
     }
 
     // OGP doesn't support an author property, so we need to delegate to the oEmbed endpoint
-    const oembedEndpointUrl = `${req.protocol}://${req.get('host')}/api/oembed?author=${encodeURIComponent(info.author)}` 
+    const oembedEndpointUrl = `${req.protocol}://${req.get('host')}/api/oembed?author=${encodeURIComponent(info.author)}`
+
+    // Messenger only supports title + thumbnail, so cram everything into the title property if Messenger
+    const titlePropContent = isFBMessengerCrawler(ua)
+        ? `${info.title} | ${info.author} | ${info.description}`
+        : info.title
 
     // https://ogp.me
     res.send(String.raw`
         <html prefix="og: https://ogp.me/ns/website#">
             <head>
-                <title>${info.title}</title>
-                <meta property="og:title" content="${info.title}" />
+                <title>${titlePropContent}</title>
+                <meta property="og:title" content="${titlePropContent}" />
                 <meta property="og:type" content="website" />
                 <meta property="og:url" content="${gameUrl.href}" />
                 <meta property="og:description" content="${info.description}" />

--- a/server/api/link_preview.ts
+++ b/server/api/link_preview.ts
@@ -1,0 +1,54 @@
+import express from 'express';
+import _ from 'lodash'
+
+import { InfoJson } from '../../src/shared/types';
+import { getGameInfo } from '../model/game';
+import { islinkExpanderBot } from "../../utils/link_preview_util"
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+    console.log('got req', req.headers, req.body);
+    let gameUrl;
+
+    try {
+        gameUrl = new URL(req.query.url as string);
+    } catch (_) {
+        res.sendStatus(400);
+        return
+    }
+
+    const gid = gameUrl.pathname.split('/')[3]
+    const info = await getGameInfo(gid) as InfoJson;
+
+    if (_.isEmpty(info)) {
+        res.sendStatus(404);
+        return
+    }
+
+    if (!islinkExpanderBot(req.headers['user-agent'] as string)) { // In case a human accesses this endpoint
+        res.redirect(gameUrl.href)
+        return
+    }
+
+    // OGP doesn't support an author property, so we need to delegate to the oEmbed endpoint
+    const oembedEndpointUrl = `${req.protocol}://${req.get('host')}/api/oembed?author=${encodeURIComponent(info.author)}` 
+
+    // https://ogp.me
+    res.send(String.raw`
+        <html prefix="og: https://ogp.me/ns/website#">
+            <head>
+                <title>${info.title}</title>
+                <meta property="og:title" content="${info.title}" />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="${gameUrl.href}" />
+                <meta property="og:description" content="${info.description}" />
+                <meta property="og:site_name" content="downforacross.com" />
+                <link type="application/json+oembed" href=${oembedEndpointUrl} />
+                <meta name="theme-color" content="#6aa9f4">
+            </head>
+        </html>
+    `)
+});
+
+export default router;

--- a/server/api/oembed.ts
+++ b/server/api/oembed.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+import _ from 'lodash'
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+    console.log('got req', req.headers, req.body);
+
+    const author = req.query.author as string
+
+    // https://oembed.com/#section2.3
+    res.json({
+        type: 'link',
+        version: '1.0',
+        author_name: author,
+    });
+});
+
+export default router;

--- a/server/api/router.ts
+++ b/server/api/router.ts
@@ -4,6 +4,8 @@ import puzzleRouter from './puzzle';
 import gameRouter from './game';
 import recordSolveRouter from './record_solve';
 import statsRouter from './stats';
+import oEmbedRouter from './oembed'
+import linkPreviewRouter from './link_preview'
 
 const router = express.Router();
 
@@ -12,5 +14,7 @@ router.use('/puzzle', puzzleRouter);
 router.use('/game', gameRouter);
 router.use('/record_solve', recordSolveRouter);
 router.use('/stats', statsRouter);
+router.use('/oembed', oEmbedRouter);
+router.use('/link_preview', linkPreviewRouter);
 
 export default router;

--- a/server/model/game.ts
+++ b/server/model/game.ts
@@ -13,6 +13,18 @@ export async function getGameEvents(gid: string) {
   return events;
 }
 
+export async function getGameInfo(gid: string) {
+  const res = await pool.query('SELECT event_payload FROM game_events WHERE gid=$1 AND event_type=\'create\'', [gid]);
+  if (res.rowCount != 1) {
+    console.log(`Could not find info for game ${gid}`);
+    return {}
+  }
+
+  const info = res.rows[0].event_payload.params.game.info;
+  console.log(`${gid} game info: ${JSON.stringify(info)}`);
+  return info;
+}
+
 export interface GameEvent {
   user?: string; // always null actually
   timestamp: number;

--- a/utils/link_preview_util.ts
+++ b/utils/link_preview_util.ts
@@ -1,0 +1,8 @@
+const linkExpanderUserAgents = [
+    'Discordbot',
+    'Slackbot-LinkExpanding'
+]
+
+export function islinkExpanderBot(userAgent: string) {
+    return linkExpanderUserAgents.some(ua => userAgent.includes(ua))
+}

--- a/utils/link_preview_util.ts
+++ b/utils/link_preview_util.ts
@@ -1,8 +1,13 @@
-const linkExpanderUserAgents = [
-    'Discordbot',
-    'Slackbot-LinkExpanding'
-]
+const linkExpanderUserAgentSubstrings = {
+    Discord: 'Discordbot',
+    Slack: 'Slackbot-LinkExpanding',
+    FB_Messenger: 'facebookexternalhit',
+};
+
+export function isFBMessengerCrawler(userAgent: string) {
+    return userAgent.includes(linkExpanderUserAgentSubstrings.FB_Messenger)
+}
 
 export function islinkExpanderBot(userAgent: string) {
-    return linkExpanderUserAgents.some(ua => userAgent.includes(ua))
+    return Object.values(linkExpanderUserAgentSubstrings).some(ua => userAgent.includes(ua))
 }


### PR DESCRIPTION
This PR implements a feature that generates link previews (also known as "embeds") for DFAC game URLs (e.g. `https://downforacross.com/beta/game/1234567-joct`) sent in platforms such as Discord and Slack. These previews are generated by "link unfurling" crawlers on these platforms that visit the URLs posted in sent messages and search for certain tags.

Using [Vercel Middleware](https://vercel.com/docs/concepts/functions/edge-middleware), requests can be intercepted before the response is served, and if the request URL is a game URL, and if user-agent string is suggestive of a crawler, the crawler can be redirected while human users are unaffected. Crawlers are redirected to an [API endpoint ](https://github.com/shintyl/downforacross.com/blob/f11bf29120d8cdaff9575aef901995e9f5a6e7da/server/api/link_preview.ts) which returns a barebones HTML document containing [Open Graph Protocol](https://ogp.me/) tags (for that specific game), whose content populates the link preview.

Here's what the link previews look like in Discord and Slack (ignore the URLs):

![image](https://github.com/downforacross/downforacross.com/assets/14168765/e3b383df-07be-46eb-a2fe-baf61574a921)
![image](https://github.com/downforacross/downforacross.com/assets/14168765/c7d5bb70-b404-41e9-98ee-ff3ec2aa95db)

Simpler approaches, like mutating the DOM in the client-side code to include the tags, unfortunately don't work because none of these crawlers actually seem to execute JavaScript, and only see [index.html](https://github.com/downforacross/downforacross.com/blob/f11bf29120d8cdaff9575aef901995e9f5a6e7da/public/index.html)'s initial state. Another approach like moving to server-side rendering would probably take a lot of work.

Note that link previews for the Vercel preview deployment won't be generated because I don't think API changes are reflected until merge.