### PR TITLE
Fix Messenger link preview formatting

### DIFF
--- a/server/api/link_preview.ts
+++ b/server/api/link_preview.ts
@@ -38,7 +38,7 @@ router.get('/', async (req, res) => {
 
     // Messenger only supports title + thumbnail, so cram everything into the title property if Messenger
     const titlePropContent = isFBMessengerCrawler(ua)
-        ? `${info.title} | ${info.author} | ${info.description}`
+        ? [info.title, info.author, info.description].filter(Boolean).join(' | ')
         : info.title
 
     // https://ogp.me


### PR DESCRIPTION
Fix minor issue seen in https://github.com/downforacross/downforacross.com/pull/284#issuecomment-1673702485 where Messenger link previews contained an unnecessary vertical bar if the description was empty.

Missing descriptions should look like this now:
![image](https://github.com/downforacross/downforacross.com/assets/14168765/f2a8ac71-7174-4abf-aaff-41435373afca)
