### PR TITLE
Show number of squares filled by each user in Color Attribution Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ If you notice a bug or have a feature request, feel free to open an issue.
    `git clone https://github.com/downforacross/downforacross.com.git`
    `cd downforacross.com`
 
-3. Use node v14
+3. Use node v18
    `nvm install`
    `nvm use`
-   `nvm alias default 14` (optional)
+   `nvm alias default 18` (optional)
 
 4. Install Dependencies
    `yarn`

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -308,6 +308,39 @@ export default class Player extends Component {
     );
   };
 
+  renderColorAttributionCounts() {
+    if (!this.props.colorAttributionMode || this.state.error) {
+      return null;
+    }
+
+    // map from displayName to number of squares solved by that user
+    const counts = {};
+    this.props.grid.forEach((row) => {
+      row.forEach((cell) => {
+        if (cell.user_id) {
+          counts[cell.user_id] = (counts[cell.user_id] || 0) + 1;
+        }
+      });
+    });
+
+    if (Object.keys(counts).length === 0) {
+      return null;
+    }
+
+    return (
+      <div style={{marginTop: 24}}>
+        <strong>Squares filled by user</strong>
+        {Object.entries(counts)
+          .sort((x) => x[1])
+          .map(([userId, count]) => (
+            <div style={{color: this.props.users[userId]?.color}}>
+              {this.props.users[userId]?.displayName} - {count}
+            </div>
+          ))}
+      </div>
+    );
+  }
+
   render() {
     const {
       mobile,
@@ -425,6 +458,7 @@ export default class Player extends Component {
                 </div>
               </div>
             </MobileListViewControls>
+            {this.renderColorAttributionCounts()}
           </div>
         );
       }
@@ -454,6 +488,7 @@ export default class Player extends Component {
               </div>
             </div>
           </MobileGridControls>
+          {this.renderColorAttributionCounts()}
         </div>
       );
     }
@@ -492,6 +527,7 @@ export default class Player extends Component {
               </div>
             </div>
           </ListViewControls>
+          {this.renderColorAttributionCounts()}
         </div>
       );
     }
@@ -554,6 +590,7 @@ export default class Player extends Component {
             </div>
           </div>
         )}
+        {this.renderColorAttributionCounts()}
       </div>
     );
   }

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -331,7 +331,7 @@ export default class Player extends Component {
       <div style={{marginTop: 24}}>
         <strong>Squares filled by user</strong>
         {Object.entries(counts)
-          .sort((x) => x[1])
+          .sort(([, count]) => parseInt(count, 10))
           .map(([userId, count]) => (
             <div style={{color: this.props.users[userId]?.color}}>
               {this.props.users[userId]?.displayName} - {count}

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -331,7 +331,7 @@ export default class Player extends Component {
       <div style={{marginTop: 24}}>
         <strong>Squares filled by user</strong>
         {Object.entries(counts)
-          .sort(([, count]) => parseInt(count, 10))
+          .sort(([, countA], [, countB]) => countA - countB)
           .map(([userId, count]) => (
             <div style={{color: this.props.users[userId]?.color}}>
               {this.props.users[userId]?.displayName} - {count}

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -331,7 +331,7 @@ export default class Player extends Component {
       <div style={{marginTop: 24}}>
         <strong>Squares filled by user</strong>
         {Object.entries(counts)
-          .sort(([, countA], [, countB]) => countA - countB)
+          .sort(([, countA], [, countB]) => countB - countA) // descending
           .map(([userId, count]) => (
             <div style={{color: this.props.users[userId]?.color}}>
               {this.props.users[userId]?.displayName} - {count}

--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -313,7 +313,7 @@ export default class Player extends Component {
       return null;
     }
 
-    // map from displayName to number of squares solved by that user
+    // map from user_id to number of squares solved by that user
     const counts = {};
     this.props.grid.forEach((row) => {
       row.forEach((cell) => {

--- a/src/pages/Replay.js
+++ b/src/pages/Replay.js
@@ -269,42 +269,6 @@ export default class Replay extends Component {
     );
   }
 
-  renderStats() {
-    if (!this.game || this.state.error) {
-      return null;
-    }
-
-    const {grid, users} = this.game;
-
-    // map from displayName to number of squares solved by that user
-    const stats = {};
-    grid.forEach((row) => {
-      row.forEach((cell) => {
-        const name = users[cell.user_id]?.displayName;
-        if (cell.user_id) {
-          stats[name] = (stats[name] || 0) + 1;
-        }
-      });
-    });
-
-    if (Object.keys(stats).length === 0) {
-      return null;
-    }
-
-    return (
-      <div>
-        <strong>Squares filled by user</strong>
-        {Object.entries(stats)
-          .sort((x) => x[1])
-          .map(([name, count]) => (
-            <div>
-              {name} - {count}
-            </div>
-          ))}
-      </div>
-    );
-  }
-
   renderToolbar() {
     if (!this.game) return;
     const {clock, solved} = this.game;
@@ -504,7 +468,6 @@ export default class Replay extends Component {
           >
             {this.renderControls()}
           </div>
-          <div>{this.renderStats()}</div>
         </Flex>
         {/* Controls:
       Playback scrubber

--- a/src/pages/Replay.js
+++ b/src/pages/Replay.js
@@ -269,6 +269,42 @@ export default class Replay extends Component {
     );
   }
 
+  renderStats() {
+    if (!this.game || this.state.error) {
+      return null;
+    }
+
+    const {grid, users} = this.game;
+
+    // map from displayName to number of squares solved by that user
+    const stats = {};
+    grid.forEach((row) => {
+      row.forEach((cell) => {
+        const name = users[cell.user_id]?.displayName;
+        if (cell.user_id) {
+          stats[name] = (stats[name] || 0) + 1;
+        }
+      });
+    });
+
+    if (Object.keys(stats).length === 0) {
+      return null;
+    }
+
+    return (
+      <div>
+        <strong>Squares filled by user</strong>
+        {Object.entries(stats)
+          .sort((x) => x[1])
+          .map(([name, count]) => (
+            <div>
+              {name} - {count}
+            </div>
+          ))}
+      </div>
+    );
+  }
+
   renderToolbar() {
     if (!this.game) return;
     const {clock, solved} = this.game;
@@ -468,6 +504,7 @@ export default class Replay extends Component {
           >
             {this.renderControls()}
           </div>
+          <div>{this.renderStats()}</div>
         </Flex>
         {/* Controls:
       Playback scrubber


### PR DESCRIPTION
Inspired by https://github.com/downforacross/downforacross.com/issues/286

Shows the number of squares filled in by each player at each point on the Replay timeline

When scrubbed to the end of the Replay timeline, this will be the number of squares solved by each player

<img width="1033" alt="downforacross squarecounts" src="https://github.com/downforacross/downforacross.com/assets/2068049/10530998-d82c-4266-9aeb-f2f5654aed1f">

![downforacross squarecounts](https://github.com/downforacross/downforacross.com/assets/2068049/240d4210-c723-4247-9ab0-e7697d2fbaba)

