### PR TITLE
add menu toggle for mobile

### DIFF
--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -23,6 +23,7 @@ export default class Game extends Component {
       vimMode: false,
       vimInsert: false,
       colorAttributionMode: false,
+      expandMenu: false,
     };
   }
 
@@ -189,6 +190,12 @@ export default class Game extends Component {
     this.props.onToggleChat();
   };
 
+  handleToggleExpandMenu = () => {
+    this.setState((prevState) => ({
+      expandMenu: !prevState.expandMenu,
+    }));
+  };
+
   handleRefocus = () => {
     this.focus();
   };
@@ -300,7 +307,7 @@ export default class Game extends Component {
     if (!this.game) return;
     const {clock, solved} = this.game;
     const {mobile} = this.props;
-    const {pencilMode, autocheckMode, vimMode, vimInsert, listMode} = this.state;
+    const {pencilMode, autocheckMode, vimMode, vimInsert, listMode, expandMenu} = this.state;
     const {lastUpdated: startTime, totalTime: pausedTime, paused: isPaused} = clock;
     return (
       <Toolbar
@@ -312,6 +319,7 @@ export default class Game extends Component {
         pausedTime={pausedTime}
         isPaused={isPaused}
         listMode={listMode}
+        expandMenu={expandMenu}
         pencilMode={pencilMode}
         autocheckMode={autocheckMode}
         vimMode={vimMode}
@@ -329,6 +337,7 @@ export default class Game extends Component {
         onToggleAutocheck={this.handleToggleAutocheck}
         onToggleListView={this.handleToggleListView}
         onToggleChat={this.handleToggleChat}
+        onToggleExpandMenu={this.handleToggleExpandMenu}
         colorAttributionMode={this.state.colorAttributionMode}
         onToggleColorAttributionMode={() => {
           this.setState((prevState) => ({colorAttributionMode: !prevState.colorAttributionMode}));

--- a/src/components/Toolbar/Clock.js
+++ b/src/components/Toolbar/Clock.js
@@ -30,6 +30,7 @@ export default class Clock extends Component {
   componentDidMount() {
     if (this.intvl) clearInterval(this.intvl);
     this.intvl = setInterval(this.updateClock.bind(this), 1000);
+    this.updateClock();
   }
 
   componentWillUnmount() {

--- a/src/components/Toolbar/css/index.css
+++ b/src/components/Toolbar/css/index.css
@@ -137,3 +137,7 @@ code {
 .toolbar--mobile .clock {
   color: white;
 }
+
+.toolbar--mobile .toolbar--expand:last-child {
+  margin-right: 16px;
+}

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -1,6 +1,7 @@
 import './css/index.css';
 import React, {Component} from 'react';
 import {MdBorderAll, MdChatBubble, MdList, MdSlowMotionVideo} from 'react-icons/md';
+import {AiOutlineMenuFold, AiOutlineMenuUnfold} from 'react-icons/ai';
 import {RiPaintFill, RiPaintLine} from 'react-icons/ri';
 import Flex from 'react-flexview';
 import {Link} from 'react-router-dom';
@@ -59,6 +60,11 @@ export default class Toolbar extends Component {
   handleToggleChat = (e) => {
     e.preventDefault();
     this.props.onToggleChat();
+  };
+
+  handleToggleExpandMenu = (e) => {
+    e.preventDefault();
+    this.props.onToggleExpandMenu();
   };
 
   renderClockControl() {
@@ -241,6 +247,15 @@ export default class Toolbar extends Component {
 
   renderChatButton() {
     return <MdChatBubble onClick={this.handleToggleChat} className="toolbar--chat" />;
+  }
+
+  renderExpandMenuButton() {
+    const {expandMenu} = this.props;
+    return expandMenu ? (
+      <AiOutlineMenuFold onClick={this.handleToggleExpandMenu} className="toolbar--expand" />
+    ) : (
+      <AiOutlineMenuUnfold onClick={this.handleToggleExpandMenu} className="toolbar--expand" />
+    );
   }
 
   renderPencil() {
@@ -434,6 +449,7 @@ export default class Toolbar extends Component {
       onPauseClock,
       solved,
       replayMode,
+      expandMenu,
     } = this.props;
 
     if (mobile) {
@@ -441,22 +457,30 @@ export default class Toolbar extends Component {
         <Flex className="toolbar--mobile" vAlignContent="center">
           <Flex className="toolbar--mobile--top" grow={1} vAlignContent="center">
             <Link to="/">DFAC</Link>{' '}
-            <Clock
-              v2={this.props.v2}
-              startTime={startTime}
-              stopTime={stopTime}
-              pausedTime={pausedTime}
-              replayMode={replayMode}
-              isPaused={this.props.isPaused || !startTime}
-              onStart={onStartClock}
-              onPause={onPauseClock}
-            />
-            {!solved && !replayMode && this.renderCheckMenu()}
-            {!solved && !replayMode && this.renderRevealMenu()}
-            {solved && !replayMode && this.renderReplayLink()}
-            {this.renderColorAttributionToggle()}
-            {this.renderListViewButton()}
-            {this.renderChatButton()}
+            {!expandMenu ? (
+              <>
+                <Clock
+                  v2={this.props.v2}
+                  startTime={startTime}
+                  stopTime={stopTime}
+                  pausedTime={pausedTime}
+                  replayMode={replayMode}
+                  isPaused={this.props.isPaused || !startTime}
+                  onStart={onStartClock}
+                  onPause={onPauseClock}
+                />
+                {!solved && !replayMode && this.renderCheckMenu()}
+                {!solved && !replayMode && this.renderRevealMenu()}
+                {solved && !replayMode && this.renderReplayLink()}
+              </>
+            ) : (
+              <>
+                {this.renderColorAttributionToggle()}
+                {this.renderListViewButton()}
+                {this.renderChatButton()}
+              </>
+            )}
+            {this.renderExpandMenuButton()}
           </Flex>
         </Flex>
       );


### PR DESCRIPTION
### Summary
In response to #288 I tried my hand at a solution by adding a menu expansion toggle to reveal the icons that were being shrunk.

### Changes Made
- Added state variable to toggle between menus
- Added icon that shows/hides the alternative menu items on tap
- Called to update clock when mounted (otherwise it would show 00:00 for a second when toggling between menus)

### Test Plan
Show toggle hides and reveals the correct menu items as expected, and that the menu items still work:
![ezgif com-video-to-gif](https://github.com/downforacross/downforacross.com/assets/28679499/b16d66d6-3dc0-41bd-856f-7266d8f16353)


