### PR TITLE
Fix mobile username issue

### DIFF
--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -21,21 +21,25 @@ const isEmojis = (str) => {
 export default class Chat extends Component {
   constructor() {
     super();
-    const username = localStorage.getItem(this.usernameKey) || nameGenerator();
+    // We'll set the username state when we mount the component.
     this.state = {
-      username,
+      username: '',
     };
     this.chatBar = React.createRef();
     this.usernameInput = React.createRef();
   }
 
   componentDidMount() {
+    let username = this.props.initialUsername;
     const battleName = localStorage.getItem(`battle_${this.props.bid}`);
     // HACK
-    if (battleName && !localStorage.getItem(this.usernameKey)) {
+    if (battleName && !username) {
+      username = battleName;
       this.setState({username: battleName});
+    } else {
+      this.setState({username});
     }
-    this.handleUpdateDisplayName(this.state.username);
+    this.handleUpdateDisplayName(username);
   }
 
   get usernameKey() {

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -18,6 +18,8 @@ import {isMobile, rand_color} from '../lib/jsUtils';
 import * as powerupLib from '../lib/powerups';
 import {recordSolve} from '../api/puzzle.ts';
 
+import nameGenerator from '../lib/nameGenerator';
+
 export default class Game extends Component {
   constructor(props) {
     super(props);
@@ -35,6 +37,11 @@ export default class Game extends Component {
         mobile: isMobile(),
       });
     });
+    this.initialUsername = localStorage.getItem(this.usernameKey) || nameGenerator();
+  }
+
+  get usernameKey() {
+    return `username_${window.location.href}`;
   }
 
   // lifecycle stuff
@@ -160,6 +167,7 @@ export default class Game extends Component {
 
   componentDidMount() {
     this.initializeGame();
+    this.handleUpdateDisplayName(this.user.id, this.initialUsername);
   }
 
   componentWillUnmount() {
@@ -366,6 +374,7 @@ export default class Game extends Component {
         opponentData={this.opponentGame && this.opponentGame.chat}
         bid={this.state.bid}
         updateSeenChatMessage={this.updateSeenChatMessage}
+        initialUsername={this.initialUsername}
       />
     );
   }


### PR DESCRIPTION
This fixes the bug where mobile users don't get assigned a username until they open the chat. This happens because the usernames are initialized in the `Chat` component, but for mobile, the `Chat` component is not mounted until it is opened.

This PR fixes this issue by creating an `initialUsername` and updating the user's username to this value when the `Game` component mounts.

This fixes #272.