### PR TITLE
Local storage for vim mode

### DIFF
--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -11,6 +11,8 @@ import Toolbar from '../Toolbar';
 import {toArr} from '../../lib/jsUtils';
 import {toHex, darken, GREENISH} from '../../lib/colors';
 
+const vimModeKey = 'vim-mode';
+
 // component for gameplay -- incl. grid/clues & toolbar
 export default class Game extends Component {
   constructor() {
@@ -29,9 +31,11 @@ export default class Game extends Component {
 
   componentDidMount() {
     const screenWidth = window.innerWidth - 1; // this is important for mobile to fit on screen
+    const vimMode = JSON.parse(localStorage.getItem(vimModeKey)) || false;
     // with body { overflow: hidden }, it should disable swipe-to-scroll on iOS safari)
     this.setState({
       screenWidth,
+      vimMode,
     });
     this.componentDidUpdate({});
   }
@@ -151,9 +155,11 @@ export default class Game extends Component {
   };
 
   handleToggleVimMode = () => {
-    this.setState((prevState) => ({
-      vimMode: !prevState.vimMode,
-    }));
+    this.setState((prevState) => {
+      const newVimMode = !prevState.vimMode;
+      localStorage.setItem(vimModeKey, JSON.stringify(newVimMode));
+      return {vimMode: newVimMode};
+    });
   };
 
   handleVimInsert = () => {

--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -31,7 +31,12 @@ export default class Game extends Component {
 
   componentDidMount() {
     const screenWidth = window.innerWidth - 1; // this is important for mobile to fit on screen
-    const vimMode = JSON.parse(localStorage.getItem(vimModeKey)) || false;
+    let vimMode = false;
+    try {
+      vimMode = JSON.parse(localStorage.getItem(vimModeKey)) || false;
+    } catch (e) {
+      console.error('Failed to parse local storage vim mode!');
+    }
     // with body { overflow: hidden }, it should disable swipe-to-scroll on iOS safari)
     this.setState({
       screenWidth,


### PR DESCRIPTION
Resolves #291.

This PR adds local storage for the vim mode toggle to be used in the state of the `Game` component. This avoids the need to enable Vim mode every time the crossword is loaded.

Tested locally and on preview.