### PR TITLE
Added a default username that persists across games when set

### DIFF
--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -7,7 +7,7 @@ import {Link} from 'react-router-dom';
 import {MdClose} from 'react-icons/md';
 import Emoji from '../common/Emoji';
 import * as emojiLib from '../../lib/emoji';
-import nameGenerator from '../../lib/nameGenerator';
+import nameGenerator, {isFromNameGenerator} from '../../lib/nameGenerator';
 import ChatBar from './ChatBar';
 import EditableSpan from '../common/EditableSpan';
 import MobileKeyboard from '../Player/MobileKeyboard';
@@ -61,6 +61,14 @@ export default class Chat extends Component {
     this.props.onUpdateDisplayName(id, username);
     this.setState({username});
     localStorage.setItem(this.usernameKey, username);
+    // Check if localStorage has username_default, if not set it to the last
+    // updated name
+    if (
+      localStorage.getItem('username_default') != localStorage.getItem(this.usernameKey) &&
+      !isFromNameGenerator(username)
+    ) {
+      localStorage.setItem('username_default', username);
+    }
   };
 
   handleUpdateColor = (color) => {

--- a/src/lib/nameGenerator.js
+++ b/src/lib/nameGenerator.js
@@ -41,6 +41,24 @@ const adjectives = rawAdjectiveList.split(',').map(sanitize).filter(adjFilter);
 const positiveAdjectives = positiveAdjectiveList.split('\n').map(sanitize).filter(adjFilter);
 const nouns = rawNounList.split('\n').map(sanitize).filter(nounFilter);
 
+export function isFromNameGenerator(name) {
+  if (typeof name !== 'string' || name.length > 20) {
+    return false;
+  }
+
+  const parts = name.split(' ');
+  if (parts.length !== 2) {
+    return false;
+  }
+
+  const [adjective, noun] = parts;
+
+  const adjectiveExists = adjectives.includes(adjective) || positiveAdjectives.includes(adjective);
+  const nounExists = nouns.includes(noun);
+
+  return adjectiveExists && nounExists;
+}
+
 export default function nameGenerator() {
   function f() {
     const adj = Math.random() < 0.9 ? sample(positiveAdjectives) : sample(adjectives);

--- a/src/pages/Game.js
+++ b/src/pages/Game.js
@@ -37,7 +37,15 @@ export default class Game extends Component {
         mobile: isMobile(),
       });
     });
-    this.initialUsername = localStorage.getItem(this.usernameKey) || nameGenerator();
+    this.initialUsername =
+      localStorage.getItem(this.usernameKey) !== null
+        ? // If localStorage has a username for this game use that, if not
+          // check if there's a default username, if there is none, use the
+          // name generator
+          localStorage.getItem(this.usernameKey)
+        : localStorage.getItem('username_default') !== null
+        ? localStorage.getItem('username_default')
+        : nameGenerator();
   }
 
   get usernameKey() {
@@ -220,6 +228,7 @@ export default class Game extends Component {
     return `user_color`;
   }
 
+  //TODO (jackz): this is how color is persisted
   get userColor() {
     const color =
       this.game.users[this.props.id]?.color || localStorage.getItem(this.userColorKey) || rand_color();


### PR DESCRIPTION
This code change adds a `default_username` to the localStorage that is only set when the user updates their username to something that is not a randomly generated name. This value is then checked when other games are loaded and if it is set, is used instead of the randomly generated name.

Here's the state of local storage after a new game is created:
![image](https://github.com/downforacross/downforacross.com/assets/68999131/13207099-5d8a-4bbb-bbf6-91336cf891de)

Here's the state of local storage after the username is updated:
![image](https://github.com/downforacross/downforacross.com/assets/68999131/77bf93b4-40a6-49ad-bfd8-1dd6fd7d0ddf)

Here's the state of a new game after the `username_default` is set:
![image](https://github.com/downforacross/downforacross.com/assets/68999131/71c6adab-a396-40f3-923f-2e03f872741c)
