### PR TITLE
Create and focus an invisible input field on click.

### DIFF
--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -185,13 +185,11 @@ export default class Cell extends React.Component<Props> {
 
   handleClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
     e.preventDefault?.();
-    e.stopPropagation?.();
     this.props.onClick(this.props.r, this.props.c);
   };
 
   handleRightClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
     e.preventDefault?.();
-    e.stopPropagation?.();
     this.props.onContextMenu(this.props.r, this.props.c);
   };
 
@@ -255,22 +253,6 @@ export default class Cell extends React.Component<Props> {
           style={style}
           onClick={this.handleClick}
           onContextMenu={this.handleRightClick}
-          onTouchStart={(e) => {
-            const touch = e.touches[e.touches.length - 1];
-            this.touchStart = {pageX: touch.pageX, pageY: touch.pageY};
-          }}
-          onTouchEnd={(e) => {
-            if (e.changedTouches.length !== 1 || e.touches.length !== 0) return;
-            const touch = e.changedTouches[0];
-            if (
-              !this.touchStart ||
-              (Math.abs(touch.pageX - this.touchStart.pageX) < 5 &&
-                Math.abs(touch.pageY - this.touchStart.pageY) < 5)
-            ) {
-              e.preventDefault();
-              onClick(this.props.r, this.props.c);
-            }
-          }}
         >
           <div className="cell--wrapper">
             <div

--- a/src/components/Player/GridControls.js
+++ b/src/components/Player/GridControls.js
@@ -13,6 +13,11 @@ function safe_while(condition, step, cap = 500) {
 }
 
 export default class GridControls extends Component {
+  constructor() {
+    super();
+    this.inputRef = React.createRef();
+  }
+
   actions = {
     left: this.setDirectionWithCallback('across', this.moveSelectedBy(0, -1).bind(this)).bind(this),
     up: this.setDirectionWithCallback('down', this.moveSelectedBy(-1, 0).bind(this)).bind(this),
@@ -226,7 +231,7 @@ export default class GridControls extends Component {
       l: 'right',
       x: 'delete',
       '^': 'home',
-      '$': 'end',
+      $: 'end',
     };
 
     const {onVimNormal, onVimInsert, vimInsert, onPressEnter, onPressPeriod} = this.props;
@@ -268,12 +273,17 @@ export default class GridControls extends Component {
     }
   };
 
+  handleClick(ev) {
+    ev.preventDefault();
+    this.focus();
+  }
+
   // takes in a Keyboard Event
   handleKeyDown(ev) {
     const {vimMode} = this.props;
     const _handleKeyDown = vimMode ? this._handleKeyDownVim : this._handleKeyDown;
 
-    if (ev.target.tagName === 'INPUT' || ev.metaKey || ev.ctrlKey) {
+    if (ev.target !== this.inputRef && (ev.tagName === 'INPUT' || ev.metaKey || ev.ctrlKey)) {
       return;
     }
     if (_handleKeyDown(ev.key, ev.shiftKey, ev.altKey)) {
@@ -391,18 +401,36 @@ export default class GridControls extends Component {
   }
 
   focus() {
-    this.refs.gridControls.focus();
+    this.inputRef.current.focus();
   }
 
   render() {
+    const gridProps = {
+      style: {
+        // Disable double-tap-to-zoom as it delays clicks by up to 300ms (to see if it becomes a double-tap)
+        touchAction: 'manipulation',
+      },
+    };
+    const inputProps = {
+      style: {
+        opacity: 0,
+        width: 0,
+        height: 0,
+      },
+      autoComplete: 'none',
+      autoCapitalize: 'none',
+    };
     return (
       <div
         ref="gridControls"
         className="grid-controls"
         tabIndex="1"
+        onClick={this.handleClick.bind(this)}
         onKeyDown={this.handleKeyDown.bind(this)}
+        {...gridProps}
       >
         <div className="grid--content">{this.props.children}</div>
+        <input tabIndex={-1} name="grid" ref={this.inputRef} {...inputProps} />
       </div>
     );
   }

--- a/src/components/Player/GridControls.js
+++ b/src/components/Player/GridControls.js
@@ -401,7 +401,7 @@ export default class GridControls extends Component {
   }
 
   focus() {
-    this.inputRef.current.focus();
+    this.inputRef.current.focus({preventScroll: true});
   }
 
   render() {

--- a/src/components/Player/css/gridControls.css
+++ b/src/components/Player/css/gridControls.css
@@ -3,7 +3,7 @@
   position: relative;
 }
 
-.grid-controls:focus .grid--content .blurable {
+.grid-controls:focus-within .grid--content .blurable {
   opacity: 1;
 }
 


### PR DESCRIPTION
This fixes #192, allowing using the non-mobile interface on devices without keyboards as having a focused input field triggers the virtual keyboard on devices that need it.