### PR TITLE
Add autocheck button to mobile toolbar.

### DIFF
--- a/src/components/Toolbar/css/index.css
+++ b/src/components/Toolbar/css/index.css
@@ -99,6 +99,13 @@ code {
   color: var(--main-blue) !important;
 }
 
+.toolbar--mobile .toolbar--autocheck {
+  color: var(--main-gray-2);
+}
+.toolbar--mobile .toolbar--autocheck.on .fa-check-square {
+  color: white !important;
+}
+
 .toolbar--mobile {
   height: 48px;
   background-color: var(--main-blue);

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -488,6 +488,7 @@ export default class Toolbar extends Component {
               <>
                 {this.renderColorAttributionToggle()}
                 {this.renderListViewButton()}
+                {this.renderAutocheck()}
                 {this.renderChatButton()}
               </>
             )}


### PR DESCRIPTION
This adds the autocheck button to the expanded menu on the mobile toolbar with updated styling to make its state visible above the blue menubar.