### PR TITLE
Fix backspace behavior on mobile.

### DIFF
--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -432,12 +432,26 @@ export default class MobileGridControls extends GridControls {
     }
   };
 
+  /**
+   * There are hidden input boxes on the page, this handler listens for changes and then relays the inferred
+   * user input to the crossword grid. The input box has a well-defined initial state that we always reset to:
+   * It has a value of "$", and the cursor is always at the end.
+   *
+   * By comparing with this initial state, we can infer what the user did, i.e. if the new value is "$a" they
+   * input the letter "a", if the new value is "", then they did a backspace.
+   */
   handleInputChange = (e) => {
-    let input = e.target.value;
+    const textArea = e.target;
+    let input = textArea.value;
     this.setState({dbgstr: `INPUT IS [${input}]`});
 
     if (input === '') {
       this.backspace();
+
+      // On some devices, the cursor gets stuck at position 0, even after the input box resets its value to "$".
+      // To counter that, wait until after the render and then set it to the end. Use a direct reference to the
+      // input in the timeout closure; the event is not reliable, nor is this.inputRef.
+      setTimeout(() => (textArea.selectionStart = textArea.value.length));
       return;
     }
 
@@ -476,7 +490,7 @@ export default class MobileGridControls extends GridControls {
 
   renderMobileInputs() {
     const inputProps = {
-      value: '$',
+      value: '$', // This resets the input to contain just "$" on every render.
       type: 'email',
       style: {
         opacity: 0,


### PR DESCRIPTION
From reading the code, I've inferred that the input box has a well-defined initial state that we always reset to: It has a value of "$", and the cursor is always at the end.

In cases where the cursor is NOT at the end as expected, we see two error cases:
- User enters a letter, the change handler fires with input like "a$", and "$" is incorrectly entered in the grid.
- User attempts to backspace, and the change handler does not fire at all because the cursor was at position 0 (Fixes #317)

I've developed and tested this fix using an android emulator attached to a chrome debug window.