### PR TITLE
Allow username editing on mobile

### DIFF
--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -220,7 +220,8 @@ export default class Chat extends Component {
         <EditableSpan
           ref={this.usernameInput}
           className="chat--username--input"
-          mobile={this.props.mobile}
+          // even when on mobile, we always want this to be editable
+          mobile={false}
           value={this.state.username}
           onChange={this.handleUpdateDisplayName}
           onBlur={this.handleBlur}

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -220,8 +220,6 @@ export default class Chat extends Component {
         <EditableSpan
           ref={this.usernameInput}
           className="chat--username--input"
-          // even when on mobile, we always want this to be editable
-          mobile={false}
           value={this.state.username}
           onChange={this.handleUpdateDisplayName}
           onBlur={this.handleBlur}

--- a/src/components/common/EditableSpan.js
+++ b/src/components/common/EditableSpan.js
@@ -86,24 +86,6 @@ export default class EditableSpan extends PureComponent {
     return new Caret(this.span.current && this.span.current.childNodes[0]);
   }
 
-  handleKeyDownMobile = (key) => {
-    const {caret} = this.state;
-    let newCaret = caret;
-    if (key === '{enter}') {
-      this.props.onPressEnter && this.props.onPressEnter();
-      return;
-    }
-    if (key === '{del}') {
-      this.text = this.text.substring(0, caret - 1) + this.text.substring(caret);
-      newCaret = caret - 1;
-    } else {
-      this.text = this.text.substring(0, caret) + key + this.text.substring(caret);
-      newCaret = caret + 1;
-    }
-    this.props.onChange(this.text);
-    this.setState({caret: newCaret});
-  };
-
   handleKeyDown = (e) => {
     if (e.key === 'Tab') {
       return;
@@ -139,7 +121,10 @@ export default class EditableSpan extends PureComponent {
           style={style}
           className={`editable-span ${this.props.className || ''}`}
           ref={this.span}
-          contentEditable={this.props.mobile ? undefined : true}
+          contentEditable
+          role="textbox"
+          aria-label="Editable text"
+          tabIndex={0}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           onKeyDown={this.handleKeyDown}

--- a/src/components/common/EditableSpan.js
+++ b/src/components/common/EditableSpan.js
@@ -34,8 +34,6 @@ export default class EditableSpan extends PureComponent {
         this.caret.startPosition = snapshot.start;
       }
       if (snapshot.focused) this.focus();
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({caret: this.text.length});
     }
   }
 


### PR DESCRIPTION
I do the crossword every morning with my friends. When I do it on mobile, I can't set my username so I always have to awkwardly leave a chat message saying my name

This PR fixes that!

Disclaimer: this is technically untested, because staging API is hanging, but I edited the HTML locally on prod to produce the same effect, and it worked great.