### PR TITLE
Fix scroll bug

### DIFF
--- a/server/model/pool.ts
+++ b/server/model/pool.ts
@@ -6,7 +6,9 @@ export const pool = new pg.Pool({
   user: process.env.PGUSER || process.env.USER,
   password: process.env.PGPASSWORD,
   database: process.env.PGDATABASE,
-  ssl: {
-    rejectUnauthorized: false,
-  }
+  ...(process.env.NODE_ENV === 'production' && {
+    ssl: {
+      rejectUnauthorized: false,
+    },
+  }),
 });

--- a/src/components/ListView/ListView.tsx
+++ b/src/components/ListView/ListView.tsx
@@ -63,7 +63,7 @@ const ListView: React.FC<ListViewProps> = (props) => {
       }
       prevSelectedRef.current = selectedClue;
     }
-  }); // Run after every render to check for selection changes
+  }, [props.clues, props.isClueSelected]); // Only run when clues or selection state changes
 
   const isSelected = (r: number, c: number, dir: 'across' | 'down' = props.direction) =>
     r === props.selected.r && c === props.selected.c && dir === props.direction;
@@ -189,15 +189,16 @@ const ListView: React.FC<ListViewProps> = (props) => {
           <div className="list-view--list" key={i}>
             <div className="list-view--list--title">{dir.toUpperCase()}</div>
             {clues[dir].map(
-              (clue, i) =>
+              (clue, clueIndex) =>
                 clue && (
+                  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
                   <div
                     className="list-view--list--clue"
-                    key={i}
-                    ref={props.isClueSelected(dir, i) ? selectedClueRef : null}
-                    onClick={() => props.selectClue(dir, i)}
+                    key={clue}
+                    ref={props.isClueSelected(dir, clueIndex) ? selectedClueRef : null}
+                    onClick={() => props.selectClue(dir, clueIndex)}
                   >
-                    <div className="list-view--list--clue--number">{i}</div>
+                    <div className="list-view--list--clue--number">{clueIndex}</div>
                     <div className="list-view--list--clue--text">
                       <Clue text={clue} />
                     </div>
@@ -206,15 +207,15 @@ const ListView: React.FC<ListViewProps> = (props) => {
                       <table className={`grid ${sizeClass}`}>
                         <tbody>
                           <RerenderBoundary
-                            name={`${dir} clue ${i}`}
-                            key={i}
-                            hash={hashGridRow(cluesCells[dir][i], {
+                            name={`${dir} clue ${clueIndex}`}
+                            key={`${dir}-${clue}`}
+                            hash={hashGridRow(cluesCells[dir][clueIndex], {
                               ...props.cellStyle,
                               size: props.size,
                             })}
                           >
                             <tr>
-                              {cluesCells[dir][i].map((cellProps) => (
+                              {cluesCells[dir][clueIndex].map((cellProps) => (
                                 <td
                                   key={`${cellProps.r}_${cellProps.c}`}
                                   className="grid--cell"
@@ -226,6 +227,7 @@ const ListView: React.FC<ListViewProps> = (props) => {
                                   }}
                                 >
                                   <Cell
+                                    // eslint-disable-next-line react/jsx-props-no-spreading
                                     {...cellProps}
                                     onClick={(r, c) => handleClick(r, c, dir)}
                                     onContextMenu={handleRightClick}

--- a/src/components/ListView/ListView.tsx
+++ b/src/components/ListView/ListView.tsx
@@ -1,7 +1,7 @@
 import './css/listView.css';
 
 import _ from 'lodash';
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import GridWrapper from '../../lib/wrappers/GridWrapper';
 import {toCellIndex} from '../../shared/types';
 import Cell from '../Grid/Cell';
@@ -10,7 +10,6 @@ import {hashGridRow} from '../Grid/hashGridRow';
 import {ClueCoords, EnhancedGridData} from '../Grid/types';
 import RerenderBoundary from '../RerenderBoundary';
 import Clue from '../Player/ClueText';
-import {lazy} from '../../lib/jsUtils';
 
 interface ListViewProps extends GridProps {
   clues: {across: string[]; down: string[]};
@@ -18,146 +17,149 @@ interface ListViewProps extends GridProps {
   selectClue: (dir: 'across' | 'down', i: number) => void;
 }
 
-export default class ListView extends React.PureComponent<ListViewProps> {
-  _scrollToClue = this.scrollToClue.bind(this);
+type SelectedClue = {
+  dir: 'across' | 'down';
+  num: number;
+};
 
-  get grid() {
-    return new GridWrapper(this.props.grid);
-  }
+const ListView: React.FC<ListViewProps> = (props) => {
+  const selectedClueRef = useRef<HTMLDivElement>(null);
+  const prevSelectedRef = useRef<SelectedClue | null>(null);
 
-  get opponentGrid() {
-    return this.props.opponentGrid && new GridWrapper(this.props.opponentGrid);
-  }
+  const grid = new GridWrapper(props.grid);
+  const opponentGrid = props.opponentGrid && new GridWrapper(props.opponentGrid);
 
-  get selectedIsWhite() {
-    const {selected} = this.props;
-    return this.grid.isWhite(selected.r, selected.c);
-  }
+  const selectedIsWhite = grid.isWhite(props.selected.r, props.selected.c);
 
-  isSelected(r: number, c: number, dir: 'across' | 'down' = this.props.direction) {
-    const {selected, direction} = this.props;
-    return r === selected.r && c === selected.c && dir == direction;
-  }
+  useEffect(() => {
+    // Find currently selected clue
+    let selectedClue: SelectedClue | null = null;
 
-  isCircled(r: number, c: number) {
-    const {grid, circles} = this.props;
-    const idx = toCellIndex(r, c, grid[0].length);
-    return (circles || []).indexOf(idx) !== -1;
-  }
+    // Explicitly type the direction to help TypeScript understand
+    type Direction = 'across' | 'down';
+    const directions: Direction[] = ['across', 'down'];
 
-  isDoneByOpponent(r: number, c: number) {
-    if (!this.opponentGrid || !this.props.solution) {
-      return false;
-    }
-    return (
-      this.opponentGrid.isFilled(r, c) && this.props.solution[r][c] === this.props.opponentGrid[r][c].value
-    );
-  }
+    directions.forEach((dir) => {
+      props.clues[dir].forEach((clue, i) => {
+        if (clue && props.isClueSelected(dir, i)) {
+          selectedClue = {dir, num: i} as SelectedClue;
+        }
+      });
+    });
 
-  isShaded(r: number, c: number) {
-    const {grid, shades} = this.props;
-    const idx = toCellIndex(r, c, grid[0].length);
-    return (shades || []).indexOf(idx) !== -1 || this.isDoneByOpponent(r, c);
-  }
-
-  isHighlighted(r: number, c: number, dir: 'across' | 'down' = this.props.direction) {
-    if (!this.selectedIsWhite) return false;
-    const {selected, direction} = this.props;
-    const selectedParent = this.grid.getParent(selected.r, selected.c, direction);
-    return (
-      !this.isSelected(r, c, dir) &&
-      this.grid.isWhite(r, c) &&
-      this.grid.getParent(r, c, direction) === selectedParent &&
-      direction == dir
-    );
-  }
-
-  isReferenced(r: number, c: number, dir: 'across' | 'down') {
-    return this.props.references.some((clue) => this.clueContainsSquare(clue, r, c, dir));
-  }
-
-  getPickup(r: number, c: number) {
-    return (
-      this.props.pickups &&
-      _.get(
-        _.find(this.props.pickups, ({i, j, pickedUp}) => i === r && j === c && !pickedUp),
-        'type'
-      )
-    );
-  }
-
-  handleClick = (r: number, c: number, dir: 'across' | 'down') => {
-    if (!this.grid.isWhite(r, c) && !this.props.editMode) return;
-    if (dir !== this.props.direction) {
-      this.props.onChangeDirection();
-    }
-    this.props.onSetSelected({r, c});
-  };
-
-  handleRightClick = (r: number, c: number) => {
-    this.props.onPing && this.props.onPing(r, c);
-  };
-
-  clueContainsSquare({ori, num}: ClueCoords, r: number, c: number, dir: 'across' | 'down') {
-    return this.grid.isWhite(r, c) && this.grid.getParent(r, c, ori) === num && ori == dir;
-  }
-
-  getSizeClass(size: number) {
-    if (size < 20) {
-      return 'tiny';
-    }
-    if (size < 25) {
-      return 'small';
-    }
-    if (size < 40) {
-      return 'medium';
-    }
-    return 'big';
-  }
-
-  scrollToClue(dir: 'across' | 'down', num: number, el: any) {
-    if (el) {
-      lazy(`scrollToClue${dir}${num}`, () => {
-        const parent = el.offsetParent;
+    // Only scroll if selected clue changed
+    if (
+      selectedClue &&
+      (!prevSelectedRef.current ||
+        prevSelectedRef.current.dir !== (selectedClue as SelectedClue).dir ||
+        prevSelectedRef.current.num !== (selectedClue as SelectedClue).num)
+    ) {
+      const el = selectedClueRef.current;
+      if (el) {
+        const parent = el.offsetParent as HTMLElement;
         if (parent) {
           parent.scrollTop = el.offsetTop - parent.offsetHeight * 0.2;
         }
-      });
+      }
+      prevSelectedRef.current = selectedClue;
     }
-  }
+  }); // Run after every render to check for selection changes
 
-  mapGridToClues() {
+  const isSelected = (r: number, c: number, dir: 'across' | 'down' = props.direction) =>
+    r === props.selected.r && c === props.selected.c && dir === props.direction;
+
+  const isCircled = (r: number, c: number) => {
+    const idx = toCellIndex(r, c, props.grid[0].length);
+    return (props.circles || []).indexOf(idx) !== -1;
+  };
+
+  const isDoneByOpponent = (r: number, c: number) =>
+    !!(
+      opponentGrid &&
+      props.solution &&
+      opponentGrid.isFilled(r, c) &&
+      props.solution[r][c] === props.opponentGrid[r][c].value
+    );
+
+  const isShaded = (r: number, c: number) => {
+    const idx = toCellIndex(r, c, props.grid[0].length);
+    return (props.shades || []).indexOf(idx) !== -1 || isDoneByOpponent(r, c);
+  };
+
+  const isHighlighted = (r: number, c: number, dir: 'across' | 'down' = props.direction) => {
+    if (!selectedIsWhite) return false;
+    const selectedParent = grid.getParent(props.selected.r, props.selected.c, props.direction);
+    return (
+      !isSelected(r, c, dir) &&
+      grid.isWhite(r, c) &&
+      grid.getParent(r, c, props.direction) === selectedParent &&
+      props.direction === dir
+    );
+  };
+
+  const isReferenced = (r: number, c: number, dir: 'across' | 'down') =>
+    props.references.some((clue) => clueContainsSquare(clue, r, c, dir));
+
+  const getPickup = (r: number, c: number) =>
+    props.pickups &&
+    _.get(
+      _.find(props.pickups, ({i, j, pickedUp}) => i === r && j === c && !pickedUp),
+      'type'
+    );
+
+  const handleClick = (r: number, c: number, dir: 'across' | 'down') => {
+    if (!grid.isWhite(r, c) && !props.editMode) return;
+    if (dir !== props.direction) {
+      props.onChangeDirection();
+    }
+    props.onSetSelected({r, c});
+  };
+
+  const handleRightClick = (r: number, c: number) => {
+    props.onPing && props.onPing(r, c);
+  };
+
+  const clueContainsSquare = ({ori, num}: ClueCoords, r: number, c: number, dir: 'across' | 'down') =>
+    grid.isWhite(r, c) && grid.getParent(r, c, ori) === num && ori === dir;
+
+  const getSizeClass = (size: number) => {
+    if (size < 20) return 'tiny';
+    if (size < 25) return 'small';
+    if (size < 40) return 'medium';
+    return 'big';
+  };
+
+  const mapGridToClues = () => {
     const cluesCells = {across: [] as EnhancedGridData, down: [] as EnhancedGridData};
-    this.props.grid.forEach((row, r) => {
+    props.grid.forEach((row, r) => {
       row.forEach((cell, c) => {
         const enhancedCell = {
           ...cell,
           r,
           c,
           number: undefined,
-          solvedByIconSize: Math.round(this.props.size / 10),
+          solvedByIconSize: Math.round(props.size / 10),
           selected: false,
           highlighted: false,
           referenced: false,
-          circled: this.isCircled(r, c),
-          shaded: this.isShaded(r, c),
-          canFlipColor: !!this.props.canFlipColor?.(r, c),
-          cursors: (this.props.cursors || []).filter((cursor) => cursor.r === r && cursor.c === c),
-          pings: (this.props.pings || []).filter((ping) => ping.r === r && ping.c === c),
-
-          myColor: this.props.myColor,
-          frozen: this.props.frozen,
-          pickupType: this.getPickup(r, c),
-          cellStyle: this.props.cellStyle,
+          circled: isCircled(r, c),
+          shaded: isShaded(r, c),
+          canFlipColor: !!props.canFlipColor?.(r, c),
+          cursors: (props.cursors || []).filter((cursor) => cursor.r === r && cursor.c === c),
+          pings: (props.pings || []).filter((ping) => ping.r === r && ping.c === c),
+          myColor: props.myColor,
+          frozen: props.frozen,
+          pickupType: getPickup(r, c),
+          cellStyle: props.cellStyle,
         };
         if (_.isNumber(cell.parents?.across)) {
           const acrossIdx = cell.parents?.across as number;
           cluesCells.across[acrossIdx] = cluesCells.across[acrossIdx] || [];
           cluesCells.across[acrossIdx].push({
             ...enhancedCell,
-            selected: this.isSelected(r, c, 'across'),
-            highlighted: this.isHighlighted(r, c, 'across'),
-            referenced: this.isReferenced(r, c, 'across'),
+            selected: isSelected(r, c, 'across'),
+            highlighted: isHighlighted(r, c, 'across'),
+            referenced: isReferenced(r, c, 'across'),
           });
         }
         if (_.isNumber(cell.parents?.down)) {
@@ -165,86 +167,85 @@ export default class ListView extends React.PureComponent<ListViewProps> {
           cluesCells.down[downIdx] = cluesCells.down[downIdx] || [];
           cluesCells.down[downIdx].push({
             ...enhancedCell,
-            selected: this.isSelected(r, c, 'down'),
-            highlighted: this.isHighlighted(r, c, 'down'),
-            referenced: this.isReferenced(r, c, 'down'),
+            selected: isSelected(r, c, 'down'),
+            highlighted: isHighlighted(r, c, 'down'),
+            referenced: isReferenced(r, c, 'down'),
           });
         }
       });
     });
 
     return cluesCells;
-  }
+  };
 
-  render() {
-    const {size, clues} = this.props;
-    const sizeClass = this.getSizeClass(size);
+  const {size, clues} = props;
+  const sizeClass = getSizeClass(size);
+  const cluesCells = mapGridToClues();
 
-    const cluesCells = this.mapGridToClues();
-
-    return (
-      <div className="list-view">
-        <div className="list-view--scroll">
-          {(['across', 'down'] as ('across' | 'down')[]).map((dir, i) => (
-            <div className="list-view--list" key={i}>
-              <div className="list-view--list--title">{dir.toUpperCase()}</div>
-              {clues[dir].map(
-                (clue, i) =>
-                  clue && (
-                    <div
-                      className="list-view--list--clue"
-                      key={i}
-                      ref={this.props.isClueSelected(dir, i) ? this._scrollToClue.bind(this, dir, i) : null}
-                      onClick={this.props.selectClue.bind(this, dir, i)}
-                    >
-                      <div className="list-view--list--clue--number">{i}</div>
-                      <div className="list-view--list--clue--text">
-                        <Clue text={clue} />
-                      </div>
-                      <div className="list-view--list--clue--break"></div>
-                      <div className="list-view--list--clue--grid">
-                        <table className={`grid ${sizeClass}`}>
-                          <tbody>
-                            <RerenderBoundary
-                              name={`${dir} clue ${i}`}
-                              key={i}
-                              hash={hashGridRow(cluesCells[dir][i], {
-                                ...this.props.cellStyle,
-                                size: this.props.size,
-                              })}
-                            >
-                              <tr>
-                                {cluesCells[dir][i].map((cellProps) => (
-                                  <td
-                                    key={`${cellProps.r}_${cellProps.c}`}
-                                    className="grid--cell"
-                                    data-rc={`${cellProps.r} ${cellProps.c}`}
-                                    style={{
-                                      width: size,
-                                      height: size,
-                                      fontSize: `${size * 0.15}px`,
-                                    }}
-                                  >
-                                    <Cell
-                                      {...cellProps}
-                                      onClick={(r, c) => this.handleClick(r, c, dir)}
-                                      onContextMenu={this.handleRightClick}
-                                      onFlipColor={this.props.onFlipColor}
-                                    />
-                                  </td>
-                                ))}
-                              </tr>
-                            </RerenderBoundary>
-                          </tbody>
-                        </table>
-                      </div>
+  return (
+    <div className="list-view">
+      <div className="list-view--scroll">
+        {(['across', 'down'] as const).map((dir, i) => (
+          <div className="list-view--list" key={i}>
+            <div className="list-view--list--title">{dir.toUpperCase()}</div>
+            {clues[dir].map(
+              (clue, i) =>
+                clue && (
+                  <div
+                    className="list-view--list--clue"
+                    key={i}
+                    ref={props.isClueSelected(dir, i) ? selectedClueRef : null}
+                    onClick={() => props.selectClue(dir, i)}
+                  >
+                    <div className="list-view--list--clue--number">{i}</div>
+                    <div className="list-view--list--clue--text">
+                      <Clue text={clue} />
                     </div>
-                  )
-              )}
-            </div>
-          ))}
-        </div>
+                    <div className="list-view--list--clue--break" />
+                    <div className="list-view--list--clue--grid">
+                      <table className={`grid ${sizeClass}`}>
+                        <tbody>
+                          <RerenderBoundary
+                            name={`${dir} clue ${i}`}
+                            key={i}
+                            hash={hashGridRow(cluesCells[dir][i], {
+                              ...props.cellStyle,
+                              size: props.size,
+                            })}
+                          >
+                            <tr>
+                              {cluesCells[dir][i].map((cellProps) => (
+                                <td
+                                  key={`${cellProps.r}_${cellProps.c}`}
+                                  className="grid--cell"
+                                  data-rc={`${cellProps.r} ${cellProps.c}`}
+                                  style={{
+                                    width: size,
+                                    height: size,
+                                    fontSize: `${size * 0.15}px`,
+                                  }}
+                                >
+                                  <Cell
+                                    {...cellProps}
+                                    onClick={(r, c) => handleClick(r, c, dir)}
+                                    onContextMenu={handleRightClick}
+                                    onFlipColor={props.onFlipColor}
+                                  />
+                                </td>
+                              ))}
+                            </tr>
+                          </RerenderBoundary>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                )
+            )}
+          </div>
+        ))}
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+export default ListView;


### PR DESCRIPTION
Context:
- Two users (A and B) are both looking at the clue list in a game
- User A scrolls all the way down to the bottom of the clue list without clicking anything
- User B clicks anywhere on the clue list

Expected behavior:
- Nothing should happen for User A
- User B should have the clue move 20% away from the top of the screen

Observed behavior:
- User A has their scroll position reset to their last-selected clue

---

I tried writing this a bunch of different ways as a class component, none of them worked. So I ended up opting for a standard functional component. As a result, the diff is bigger than I'd like. I haven't tested it with vim mode, but everything else functions as expected.

---

Note that the refactor into a functional component was 90% Claude's doing, I tested a bunch after but am operating partially blind.