### PR TITLE
win indicator for fencing

### DIFF
--- a/src/components/Fencing/FencingScoreboard.tsx
+++ b/src/components/Fencing/FencingScoreboard.tsx
@@ -53,10 +53,17 @@ export const FencingScoreboard: React.FC<{
   );
 
   // Determine if the game is complete and which team won
+  // should be able to handle ties with any number of teams
   const isGameComplete = props.gameState.game?.grid.every((row) =>
     row.every((cell) => cell.good || cell.black)
   );
-  const winningTeam = isGameComplete ? _.maxBy(_.values(props.gameState.teams), 'score') : null;
+  const winningTeams = isGameComplete
+    ? (() => {
+        const teams = _.values(props.gameState.teams).filter(Boolean);
+        const maxScore = _.maxBy(teams, 'score')?.score;
+        return teams.filter((team) => team?.score === maxScore);
+      })()
+    : null;
 
   const teamData = _.keys(props.gameState.teams).map((teamId) => ({
     team: props.gameState.teams[teamId]!,
@@ -91,9 +98,6 @@ export const FencingScoreboard: React.FC<{
               {team.name}
             </span>
           )}
-          {isGameComplete && winningTeam?.id === team.id && (
-            <span className={classes.winIndicator}>🏆 Winner!</span>
-          )}
           {currentUser?.teamId === team.id && spectateButton}
           {currentUser?.teamId === 0 && (
             <button
@@ -103,6 +107,9 @@ export const FencingScoreboard: React.FC<{
             >
               Join Team
             </button>
+          )}
+          {isGameComplete && winningTeams?.some((winner) => winner?.id === team.id) && (
+            <span className={classes.winIndicator}>{winningTeams.length > 1 ? '🤝 Tie!' : '🏆 Winner!'}</span>
           )}
         </span>
       ),

--- a/src/components/Fencing/FencingScoreboard.tsx
+++ b/src/components/Fencing/FencingScoreboard.tsx
@@ -26,6 +26,11 @@ const useStyles = makeStyles({
     display: 'flex',
     justifyContent: 'space-between',
   },
+  winIndicator: {
+    marginLeft: 8,
+    color: '#4CAF50',
+    fontWeight: 'bold',
+  },
 });
 export const FencingScoreboard: React.FC<{
   gameState: GameState;
@@ -46,6 +51,13 @@ export const FencingScoreboard: React.FC<{
       Leave Team
     </button>
   );
+
+  // Determine if the game is complete and which team won
+  const isGameComplete = props.gameState.game?.grid.every((row) =>
+    row.every((cell) => cell.good || cell.black)
+  );
+  const winningTeam = isGameComplete ? _.maxBy(_.values(props.gameState.teams), 'score') : null;
+
   const teamData = _.keys(props.gameState.teams).map((teamId) => ({
     team: props.gameState.teams[teamId]!,
     users: _.values(props.gameState.users).filter((user) => String(user.teamId) === teamId),
@@ -78,6 +90,9 @@ export const FencingScoreboard: React.FC<{
             >
               {team.name}
             </span>
+          )}
+          {isGameComplete && winningTeam?.id === team.id && (
+            <span className={classes.winIndicator}>🏆 Winner!</span>
           )}
           {currentUser?.teamId === team.id && spectateButton}
           {currentUser?.teamId === 0 && (


### PR DESCRIPTION
Hi! This is my first PR on github, let me know if I'm doing it right or if there's a test suite or something like that.

This commit just adds a simple win indicator for fencing because right now it's very annoying that the fencing will end and neither team knows who won or gets to see the board.

If you would prefer a bigger commit, I'm hoping to add some other improvements to fencing on this branch after I get free in a couple weeks or so, but I'd like to merge this in so I can have more fun playing fencing with my friends in the meantime.

The specific content of this fix is in `src/components/Fencing/FencingScoreboard.tsx`, where I added a winIndicator `span` next to the winning team name that says "🏆 Winner!". It displays only if every cell is filled.