### PR TITLE
Don't flip clue when scrolling clue bar

### DIFF
--- a/src/components/Player/css/mobileGridControls.css
+++ b/src/components/Player/css/mobileGridControls.css
@@ -48,10 +48,6 @@
   overflow: hidden;
 }
 
-.mobile-grid-controls--clue-bar.touching {
-  background-image: linear-gradient(to bottom, #edffff, #dcefff);
-}
-
 .mobile-grid-controls--clue-bar--number {
   font-weight: bold;
   display: inline-block;


### PR DESCRIPTION
On Safari iOS, scrolling long clues will also flip the clue direction when you release the scroll. This makes it difficult to read the bottom of the clue and fill in an answer.

https://github.com/user-attachments/assets/d6d715c2-1980-44ea-b459-d29bdfc34e95

This PR contains a fix. Scrolling the clue will no longer flip the clue direction. Tapping the clue bar will still flip the clue direction. There's a buffer of 6 pixels for ergonomics.

https://github.com/user-attachments/assets/27dbd8f6-2e6a-49d8-ad09-096f24833d47

There was a lot of unused code in my way that I removed. This code appeared to be for an unfinished clue bar gestures feature. It was accessible via a `enableClueBarGestures` flag that was never set. I removed all code behind that flag as well as the flag, and kept the touchStart and touchEnd events for my bug fix.