### PR TITLE
fix ipuz description field

### DIFF
--- a/src/lib/converter/iPUZtoJSON.js
+++ b/src/lib/converter/iPUZtoJSON.js
@@ -26,7 +26,7 @@ export default function iPUZtoJSON(readerResult) {
     type: grid.length > 10 ? 'Daily Puzzle' : 'Mini Puzzle',
     title: jsonFromReader.title || '',
     author: jsonFromReader.author || '',
-    description: jsonFromReader.description || '',
+    description: jsonFromReader.notes || '',
   };
   const circles = [];
   const shades = [];


### PR DESCRIPTION
ipuz stores the notes in the "notes" field, not the "description" field