### PR TITLE
Improve mobile screen snapping

### DIFF
--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -22,7 +22,6 @@ export default class Game extends Component {
       listMode: false,
       pencilMode: false,
       autocheckMode: false,
-      screenWidth: 0,
       vimMode: false,
       vimInsert: false,
       vimCommand: false,
@@ -32,7 +31,6 @@ export default class Game extends Component {
   }
 
   componentDidMount() {
-    const screenWidth = window.innerWidth - 1; // this is important for mobile to fit on screen
     let vimMode = false;
     try {
       vimMode = JSON.parse(localStorage.getItem(vimModeKey)) || false;
@@ -41,7 +39,6 @@ export default class Game extends Component {
     }
     // with body { overflow: hidden }, it should disable swipe-to-scroll on iOS safari)
     this.setState({
-      screenWidth,
       vimMode,
     });
     this.componentDidUpdate({});
@@ -267,7 +264,7 @@ export default class Game extends Component {
       clues[dirToHide] = _.assign([], clues[dirToHide]).map((val) => val && '-');
     }
     const opponentGrid = this.opponentGame && this.opponentGame.grid;
-    const {screenWidth} = this.state;
+    const screenWidth = window.innerWidth - 1; // this is important for mobile to fit on screen
     const themeStyles = {
       clueBarStyle: {
         backgroundColor: toHex(themeColor),

--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -44,12 +44,15 @@ export default class MobileGridControls extends GridControls {
     // default scale already fits screen width; no need to zoom out further
     scale = Math.max(1, scale);
 
-    const PADDING = size * scale; // px
+    // this shouldn't go larger than half a tile (scaled) for now; the min X/Y
+    // calculations don't work when the difference between the usable size and
+    // grid size are positive, but smaller than PADDING
+    const PADDING = (size / 2) * scale; // px
 
     const usableWidth = visualViewport.width;
     const gridWidth = this.grid.cols * size * scale;
-    const minX = usableWidth - gridWidth;
-    const maxX = 0;
+    const minX = Math.min(0, usableWidth - gridWidth - PADDING);
+    const maxX = PADDING;
     translateX = Math.min(Math.max(translateX, minX), maxX);
 
     const usableHeight = visualViewport.height - rect.y;

--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -1,12 +1,19 @@
 import './css/mobileGridControls.css';
 
-import React from 'react';
+import React, {useEffect} from 'react';
 import Flex from 'react-flexview';
 import {MdKeyboardArrowLeft, MdKeyboardArrowRight} from 'react-icons/md';
 import _ from 'lodash';
 import Clue from './ClueText';
 import GridControls from './GridControls';
 import GridObject from '../../lib/wrappers/GridWrapper';
+
+const RunOnce = ({effect}) => {
+  useEffect(() => {
+    effect();
+  }, []);
+  return null;
+};
 
 export default class MobileGridControls extends GridControls {
   constructor() {
@@ -80,6 +87,18 @@ export default class MobileGridControls extends GridControls {
       },
       lastFitOnScreen: Date.now(),
     });
+  }
+
+  centerGridX() {
+    let {scale, translateX, translateY} = this.state.transform;
+    const usableWidth = visualViewport.width;
+    // this.props.size can't be trusted; Player.updateSize will soon recalculate
+    // it using this formula
+    const size = Math.floor(usableWidth / this.grid.cols);
+    const gridWidth = this.grid.cols * size;
+    translateX = (usableWidth - gridWidth) / 2;
+    translateY = translateX;
+    this.setState({transform: {scale, translateX, translateY}});
   }
 
   handleClueBarTouchEnd = (e) => {
@@ -448,6 +467,7 @@ export default class MobileGridControls extends GridControls {
         {this.renderMobileInputs()}
         {/* {this.renderMobileKeyboard()} */}
         {this.props.enableDebug && (this.state.dbgstr || 'No message')}
+        <RunOnce effect={this.centerGridX.bind(this)} />
       </div>
     );
   }

--- a/src/components/Player/MobileGridControls.js
+++ b/src/components/Player/MobileGridControls.js
@@ -39,17 +39,26 @@ export default class MobileGridControls extends GridControls {
 
     const rect = this.zoomContainer.current.getBoundingClientRect();
     let {scale, translateX, translateY} = this.state.transform;
-    if (scale < 1) scale = 1;
-    const minTranslateX = -rect.width * (scale - 1);
-    const maxTranslateX = 0;
-    const minTranslateY = translateY; // never auto-pan back up, because iOS soft keyboard is insane
-    // https://blog.opendigerati.com/the-eccentric-ways-of-ios-safari-with-the-keyboard-b5aa3f34228d
-    const maxTranslateY = 0;
-    translateX = _.clamp(translateX, minTranslateX, maxTranslateX);
-    translateY = _.clamp(translateY, minTranslateY, maxTranslateY);
+    const {selected, size} = this.props;
+
+    // default scale already fits screen width; no need to zoom out further
+    scale = Math.max(1, scale);
+
+    const PADDING = size * scale; // px
+
+    const usableWidth = visualViewport.width;
+    const gridWidth = this.grid.cols * size * scale;
+    const minX = usableWidth - gridWidth;
+    const maxX = 0;
+    translateX = Math.min(Math.max(translateX, minX), maxX);
+
+    const usableHeight = visualViewport.height - rect.y;
+    const gridHeight = this.grid.rows * size * scale;
+    const minY = Math.min(0, usableHeight - gridHeight - PADDING);
+    const maxY = PADDING;
+    translateY = Math.min(Math.max(translateY, minY), maxY);
 
     if (fitCurrentClue) {
-      const {selected, size} = this.props;
       const posX = selected.c * size;
       const posY = selected.r * size;
       const paddingX = (rect.width - this.grid.cols * size) / 2;

--- a/src/components/Player/css/index.css
+++ b/src/components/Player/css/index.css
@@ -97,7 +97,6 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
 }
 

--- a/src/components/Player/css/index.css
+++ b/src/components/Player/css/index.css
@@ -97,7 +97,6 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
 }
 
 .player--mobile--grid {

--- a/src/components/Player/css/mobileGridControls.css
+++ b/src/components/Player/css/mobileGridControls.css
@@ -16,7 +16,6 @@
 }
 
 .mobile-grid-controls--grid-content {
-  padding: 10px;
   overflow: hidden;
 }
 


### PR DESCRIPTION
This PR fixes a couple of issues demonstrated below

- There's a padding around the puzzle area which constricts the viewport
- The viewport snapping effect doesn't work on the y-axis

https://github.com/user-attachments/assets/dcd21d61-a415-43f4-8f59-9a2d9adcda42

Here is the new behavior after this PR

https://github.com/user-attachments/assets/2b8437a6-d831-476b-86b1-597ee71c7d5f