### PR TITLE
Sidebar of welcome page overflowing

### DIFF
--- a/src/pages/Welcome.js
+++ b/src/pages/Welcome.js
@@ -311,7 +311,12 @@ export default class Welcome extends Component {
         </div>
         <Flex grow={1} basis={1}>
           {this.showingSidebar && (
-            <Flex className="welcome--sidebar" column shrink={0} style={{justifyContent: 'space-between'}}>
+            <Flex
+              className="welcome--sidebar"
+              column
+              shrink={0}
+              style={{justifyContent: 'start', height: 'min-content', minHeight: '100%'}}
+            >
               {this.renderFilters()}
               <WelcomeVariantsControl fencing={this.props.fencing} />
               {!this.mobile && this.renderQuickUpload()}


### PR DESCRIPTION
Fixes #353  a minor bug on the Welcome page where the upload section overflows the sidebar:

Before:
<img width="1895" height="1115" alt="image" src="https://github.com/user-attachments/assets/dd8b3254-e2ee-42e0-8e6a-f9fcf36705f2" />

After:
<img width="1900" height="1096" alt="image" src="https://github.com/user-attachments/assets/3304ea8f-51bd-416b-adfe-91bb92d9543d" />

Changed `justify-content` to `start` instead of `space-between` to look closer to the original layout since it adds some extra padding on the top with `space-between` since the sidebar is longer now.
